### PR TITLE
Skip bit64 unit test if not installed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Suggests:
     bit64,
     covr,
     hms,
-    testthat (>= 0.8)
+    testthat (>= 2.0)
 LinkingTo: 
     Rcpp
 LazyLoad: yes

--- a/tests/testthat/test-bounds.r
+++ b/tests/testthat/test-bounds.r
@@ -49,6 +49,7 @@ test_that("scaling is possible with dates and times", {
 })
 
 test_that("scaling is possible with integer64 data", {
+  skip_if_not_installed("bit64")
   x <- bit64::as.integer64(2^60) + c(0:3)
   expect_equal(
     rescale_mid(x, mid = bit64::as.integer64(2^60) + 1),


### PR DESCRIPTION
`bit64` is only suggested because it appears on a unit test I wrote (#75).
As it is a suggested package, the test should be skipped if `bit64` is missing.

This hopefully has the positive side effect of making Dirk Eddelbuettel happier http://dirk.eddelbuettel.com/blog/2017/03/22/