### PR TITLE
Fix munsell example in div_gradient_pal, fixes #127

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Depends:
 Imports: 
     dichromat,
     labeling,
-    munsell (>= 0.2),
+    munsell (>= 0.5),
     R6,
     RColorBrewer,
     Rcpp,

--- a/R/pal-gradient.r
+++ b/R/pal-gradient.r
@@ -43,7 +43,7 @@ gradient_n_pal <- function(colours, values = NULL, space = "Lab") {
 #'
 #' library(munsell)
 #' image(r, col = div_gradient_pal(low =
-#'    mnsl(complement("10R 4/6", fix = TRUE)))(seq(0, 1, length = 100)))
+#'    mnsl(complement("10R 4/6"), fix = TRUE))(seq(0, 1, length = 100)))
 #' @importFrom munsell mnsl
 div_gradient_pal <- function(low = mnsl("10B 4/6"), mid = mnsl("N 8/0"), high = mnsl("10R 4/6"), space = "Lab") {
   gradient_n_pal(c(low, mid, high), space = space)

--- a/man/div_gradient_pal.Rd
+++ b/man/div_gradient_pal.Rd
@@ -29,5 +29,5 @@ image(r, col = div_gradient_pal()(seq(0, 1, length.out = 100)))
 
 library(munsell)
 image(r, col = div_gradient_pal(low =
-   mnsl(complement("10R 4/6", fix = TRUE)))(seq(0, 1, length = 100)))
+   mnsl(complement("10R 4/6"), fix = TRUE))(seq(0, 1, length = 100)))
 }


### PR DESCRIPTION
This pull request updates the example in `div_gradient_pal()` that relies on munsell, and wasn't producing expected output as documented in #127 

Bump in version of munsell required since updated example won't work with old munsell.