### PR TITLE
added label size control to show_col()

### DIFF
--- a/R/colour-manip.r
+++ b/R/colour-manip.r
@@ -78,9 +78,10 @@ alpha <- function(colour, alpha = NA) {
 #' @param colours a character vector of colours
 #' @param labels boolean, whether to show the hexadecimal representation of the colours in each tile
 #' @param borders colour of the borders of the tiles; matches the `border` argument of [graphics::rect()]. The default means `par("fg")`. Use `border = NA` to omit borders.
+#' @param cex_label size of printed labels, works the same as \code{cex} parameter of \code{plot()}
 #' @export
 #' @importFrom graphics par plot rect text
-show_col <- function(colours, labels = TRUE, borders = NULL) {
+show_col <- function(colours, labels = TRUE, borders = NULL, cex_label = 1) {
   n <- length(colours)
   ncol <- ceiling(sqrt(n))
   nrow <- ceiling(n / ncol)
@@ -97,6 +98,6 @@ show_col <- function(colours, labels = TRUE, borders = NULL) {
     col = colours, border = borders
   )
   if (labels) {
-    text(col(colours) - 0.5, -row(colours) + 0.5, colours)
+    text(col(colours) - 0.5, -row(colours) + 0.5, colours, cex = cex_label)
   }
 }

--- a/R/colour-manip.r
+++ b/R/colour-manip.r
@@ -95,7 +95,7 @@ show_col <- function(colours, labels = TRUE, borders = NULL, cex_label = 1) {
   size <- max(dim(colours))
   plot(c(0, size), c(0, -size), type = "n", xlab = "", ylab = "", axes = FALSE)
   rect(col(colours) - 1, -row(colours) + 1, col(colours), -row(colours),
-    col = colours, border = borders
+       col = colours, border = borders
   )
   if (labels) {
     text(col(colours) - 0.5, -row(colours) + 0.5, colours, cex = cex_label)

--- a/man/col_numeric.Rd
+++ b/man/col_numeric.Rd
@@ -5,6 +5,7 @@
 \alias{col_bin}
 \alias{col_quantile}
 \alias{col_factor}
+\alias{col_numeric}
 \title{Color mapping}
 \usage{
 col_numeric(palette, domain, na.color = "#808080")

--- a/man/show_col.Rd
+++ b/man/show_col.Rd
@@ -4,7 +4,7 @@
 \alias{show_col}
 \title{Show colours.}
 \usage{
-show_col(colours, labels = TRUE, borders = NULL)
+show_col(colours, labels = TRUE, borders = NULL, cex_label = 1)
 }
 \arguments{
 \item{colours}{a character vector of colours}
@@ -12,6 +12,8 @@ show_col(colours, labels = TRUE, borders = NULL)
 \item{labels}{boolean, whether to show the hexadecimal representation of the colours in each tile}
 
 \item{borders}{colour of the borders of the tiles; matches the \code{border} argument of \code{\link[graphics:rect]{graphics::rect()}}. The default means \code{par("fg")}. Use \code{border = NA} to omit borders.}
+
+\item{cex_label}{size of printed labels, works the same as \code{cex} parameter of \code{plot()}}
 }
 \description{
 A quick and dirty way to show colours in a plot.


### PR DESCRIPTION
the same here as [#87](https://github.com/r-lib/scales/pull/87), from an updated fork.

problem: trying to plot great enough matrices ( 400X400 on...) produces unreadable labels
proposed solution: giving the user control over label size.

@dpseidel code is formatted following the tidy style.