### PR TITLE
Add time_format() function for time formatting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # scales 0.5.0.9000
 
+* New function `time_format()` formats `POSIXt` and `hms` objects (@dpseidel, #88).
+
 * `rescale_mid()` now properly handles NAs (@foo-bar-baz-qux, #104).
 
 * `log_breaks()` returns integer multiples of integer powers of base when finer

--- a/R/trans-date.r
+++ b/R/trans-date.r
@@ -143,8 +143,9 @@ time_format <- function(format = "%H:%M:%S", tz = "UTC") {
       format(as.POSIXct(x), format = format, tz = tz)
     } else {
       stop(
-        "Objects of class ", paste(class(x), collapse = "/"),
-        " are not supported by time_format."
+        "time_format can't be used with objects of class ", paste(class(x), collapse = "/"),
+        ".",
+        call. = FALSE
       )
     }
   }

--- a/R/trans-date.r
+++ b/R/trans-date.r
@@ -34,7 +34,6 @@ from_date <- function(x) {
 #' t$format(t$breaks(range(hours)))
 time_trans <- function(tz = NULL) {
   force(tz)
-  
   to_time <- function(x) {
     structure(x, class = c("POSIXt", "POSIXct"), tzone = tz)
   }
@@ -126,4 +125,27 @@ date_breaks <- function(width = "1 month") {
 date_format <- function(format = "%Y-%m-%d", tz = "UTC") {
   force_all(format, tz)
   function(x) format(x, format, tz = tz)
+}
+
+#' Formatted times.
+#'
+#' @param format Time format using standard POSIX specification.  See
+#'  [strptime()] for possible formats.
+#' @param tz a time zone name, see [timezones()]. Defaults
+#'  to UTC
+#' @export
+time_format <- function(format = "%H:%M:%S", tz = "UTC") {
+  force_all(format, tz)
+  function(x) {
+    if (inherits(x, "POSIXt")) {
+      format(x, format = format, tz = tz)
+    } else if (inherits(x, "difftime")) {
+      format(as.POSIXct(x), format = format, tz = tz)
+    } else {
+      stop(
+        "Objects of class ", paste(class(x), collapse = "/"),
+        " are not supported by time_format."
+      )
+    }
+  }
 }

--- a/tests/testthat/test-trans-date.r
+++ b/tests/testthat/test-trans-date.r
@@ -43,7 +43,7 @@ test_that("tz arugment overrules default time zone", {
 
 test_that("time_format formats hms objects", {
   expect_equal(time_format()(a_time), "11:30:00")
-  skip_if_not_installed(hms)
+  skip_if_not_installed("hms")
   expect_equal(time_format()(hms::as.hms(a_time, tz = tz(a_time))), "11:30:00")
   expect_equal(time_format(format = "%H")(hms::as.hms(a_time, tz = tz(a_time))), "11")
 })

--- a/tests/testthat/test-trans-date.r
+++ b/tests/testthat/test-trans-date.r
@@ -40,3 +40,10 @@ test_that("tz arugment overrules default time zone", {
   expect_equal(tz(x), "GMT")
   expect_equal(tz2(x), "GMT")
 })
+
+test_that("time_format formats hms objects", {
+  expect_equal(time_format()(a_time), "11:30:00")
+  skip_if_not_installed(hms)
+  expect_equal(time_format()(hms::as.hms(a_time, tz = tz(a_time))), "11:30:00")
+  expect_equal(time_format(format = "%H")(hms::as.hms(a_time, tz = tz(a_time))), "11")
+})


### PR DESCRIPTION
This PR adds a new function, `time_format`, to format times properly, for both `POSIXt` and `hms` objects.  A separate function made more sense to me than did adjusting `date_format` to accommodate times, but if this code feels too redundant, I'm happy to implement changes to `date_format` instead.

I also wonder if date_format and/or time_format shouldn't be moved to formatter.r with all the other formatters. 

Addresses #88

-----------
Some notes about handling timezones for hms objects: 

For consistency, it seemed important to continue using standard POSIX specification for formatting, but while time zone of hms objects can be specified at conversion (from other datetime classes, defaults to local time) but they not have a tzone attribute themselves and can't/don't respect daylight savings (i.e. a day == 24 hours).  Coercing them back to POSIXct is easy but always sets the timezone to "UTC"  --  if our function allows the user to change this in higher level format function, times can quickly get misrepresented, especially around daylight savings time. On the other hand, if the user knows the original timezone of the hms object and set it properly during conversion, then being able to play with timezones is maybe a desirable feature.  

Ultimately I decided to go with the simplest approach and coerce hms objects to POSIXct and preserve the ability for the user to set the tz in the higher level format function but I'm curious what behavior you think is best. 

Some possible alternatives: 
- dropping the `tz` argument in line 143 OR dropping the tz argument entirely, replacing it with dots and feeding POSIXt objects directly into `date_format` which could take `tz`  when specified. It seemed a bit odd not to have a timezone argument in a formatting function for times though.
- coercing to POSIXlt instead which ignores the tz argument in format. 
- adding a warning along the lines of _"The timezone of all hms objects is assumed to be UTC.  Changing tz may result in incorrect times, please check your data carefully."_  if the user changes the tz argument and passes an hms object.

Also worth noting, while I hope anyone passing an `hms` object won't attempt to request a date-time format (especially from the explicitly named `time_format` function), as it stands, this fix doesn't do anything to prevent or warn users doing this.  If they do, the results will be incorrect (i.e. reporting from January 1970). 

