### PR TITLE
Additional arguments for scientific_format()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,9 @@
 
 * New function `number_format()`, a generic formatter for numbers (@larmarange, #142).
 
+* `scientific_format()` gains new arguments: `scale`, `prefix`, `suffix`, `decimal.mark`, 
+  `trim` (@larmarange, #147)
+
 # scales 0.5.0
 
 * New function `regular_minor_breaks()` calculates minor breaks as a property

--- a/R/formatter.r
+++ b/R/formatter.r
@@ -205,11 +205,19 @@ percent <- function(x) {
 
 #' Scientific formatter.
 #'
-#' @return a function with single parameter x, a numeric vector, that
-#'   returns a character vector
-#' @param digits number of significant digits to show
-#' @param ... other arguments passed on to [format()]
-#' @param x a numeric vector to format
+#' @return A function with single parameter `x`, a numeric vector, that
+#'   returns a character vector.
+#' @param digits Number of significant digits to show.
+#' @param scale A scaling factor: `x` will be multiply by `scale` before
+#'   formating (useful if the underlying data is on another scale,
+#'   e.g. for computing percentages or thousands).
+#' @param prefix,suffix Symbols to display before and after value.
+#' @param decimal.mark The character to be used to indicate the numeric
+#'   decimal point.
+#' @param trim Logical, if `FALSE`, values are right-justified to a common
+#'   width (see [base::format()]).
+#' @param ... Other arguments passed on to [base::format()].
+#' @param x A numeric vector to format.
 #' @export
 #' @examples
 #' scientific_format()(1:10)
@@ -218,16 +226,32 @@ percent <- function(x) {
 #' scientific(1:10)
 #' scientific(runif(10))
 #' scientific(runif(10), digits = 2)
-scientific_format <- function(digits = 3, ...) {
-  force_all(digits, ...)
-  function(x) scientific(x, digits, ...)
+#' scientific(12345, suffix = " cells/mL")
+scientific_format <- function(digits = 3, scale = 1, prefix = "", suffix = "",
+                              decimal.mark = ".", trim = TRUE, ...) {
+  force_all(digits, scale, prefix, suffix, decimal.mark, trim, ...)
+  function(x) scientific(
+    x,
+    digits = digits,
+    scale = scale,
+    prefix = prefix,
+    suffix = suffix,
+    decimal.mark = decimal.mark,
+    ...
+  )
 }
 
 #' @export
 #' @rdname scientific_format
-scientific <- function(x, digits = 3, ...) {
-  x <- signif(x, digits)
-  format(x, trim = TRUE, scientific = TRUE, ...)
+scientific <- function(x, digits = 3, scale= 1, prefix = "", suffix = "",
+                       decimal.mark = ".", trim = TRUE, ...) {
+  if (length(x) == 0) return(character())
+  x <- signif(x * scale, digits)
+  paste0(
+    prefix,
+    format(x, decimal.mark = decimal.mark, trim = trim, scientific = TRUE, ...),
+    suffix
+  )
 }
 
 #' Ordinal formatter: add ordinal suffixes (-st, -nd, -rd, -th) to numbers.

--- a/man/scientific_format.Rd
+++ b/man/scientific_format.Rd
@@ -5,20 +5,34 @@
 \alias{scientific}
 \title{Scientific formatter.}
 \usage{
-scientific_format(digits = 3, ...)
+scientific_format(digits = 3, scale = 1, prefix = "", suffix = "",
+  decimal.mark = ".", trim = TRUE, ...)
 
-scientific(x, digits = 3, ...)
+scientific(x, digits = 3, scale = 1, prefix = "", suffix = "",
+  decimal.mark = ".", trim = TRUE, ...)
 }
 \arguments{
-\item{digits}{number of significant digits to show}
+\item{digits}{Number of significant digits to show.}
 
-\item{...}{other arguments passed on to \code{\link[=format]{format()}}}
+\item{scale}{A scaling factor: \code{x} will be multiply by \code{scale} before
+formating (useful if the underlying data is on another scale,
+e.g. for computing percentages or thousands).}
 
-\item{x}{a numeric vector to format}
+\item{prefix, suffix}{Symbols to display before and after value.}
+
+\item{decimal.mark}{The character to be used to indicate the numeric
+decimal point.}
+
+\item{trim}{Logical, if \code{FALSE}, values are right-justified to a common
+width (see \code{\link[base:format]{base::format()}}).}
+
+\item{...}{Other arguments passed on to \code{\link[base:format]{base::format()}}.}
+
+\item{x}{A numeric vector to format.}
 }
 \value{
-a function with single parameter x, a numeric vector, that
-returns a character vector
+A function with single parameter \code{x}, a numeric vector, that
+returns a character vector.
 }
 \description{
 Scientific formatter.
@@ -30,4 +44,5 @@ scientific_format(digits = 2)(runif(10))
 scientific(1:10)
 scientific(runif(10))
 scientific(runif(10), digits = 2)
+scientific(12345, suffix = " cells/mL")
 }

--- a/tests/testthat/test-formatter.r
+++ b/tests/testthat/test-formatter.r
@@ -1,5 +1,7 @@
 context("Formatters")
 
+# Time formatter --------------------------------------------------------
+
 test_that("time_format formats hms objects", {
   a_time <- ISOdatetime(2012, 1, 1, 11, 30, 0, tz = "UTC")
 
@@ -8,6 +10,7 @@ test_that("time_format formats hms objects", {
   expect_equal(time_format(format = "%H")(hms::as.hms(a_time, tz = "UTC")), "11")
 })
 
+# Number formatter --------------------------------------------------------
 
 test_that("number format works correctly", {
   expect_equal(number(123.45, accuracy = 1), "123")
@@ -38,12 +41,15 @@ test_that("number_format works with Inf", {
   expect_equal(cust(c(Inf, -Inf)), c("Inf", "-Inf"))
 })
 
+# Comma formatter --------------------------------------------------------
 
 test_that("comma format always adds commas", {
   expect_equal(comma(1e3), "1,000")
   expect_equal(comma(1e6), "1,000,000")
   expect_equal(comma(1e9), "1,000,000,000")
 })
+
+# Scientific formatter --------------------------------------------------------
 
 test_that("scientific format shows specific sig figs", {
   expect_equal(scientific(123456, digits = 1), "1e+05")
@@ -54,6 +60,22 @@ test_that("scientific format shows specific sig figs", {
   expect_equal(scientific(0.123456, digits = 2), "1.2e-01")
   expect_equal(scientific(0.123456, digits = 3), "1.23e-01")
 })
+
+test_that("prefix and suffix works with scientific format", {
+  expect_equal(scientific(123456, digits = 2, prefix = "V="), "V=1.2e+05")
+  expect_equal(scientific(123456, digits = 2, suffix = " km"), "1.2e+05 km")
+})
+
+test_that("scale works with scientific format", {
+  expect_equal(scientific(123456, digits = 2, scale = 1000), "1.2e+08")
+})
+
+test_that("decimal.mark works with scientific format", {
+  expect_equal(scientific(123456, digits = 2, decimal.mark = ","), "1,2e+05")
+})
+
+
+# Wrap formatter --------------------------------------------------------
 
 test_that("wrap correctly wraps long lines", {
   expect_equal(
@@ -72,6 +94,8 @@ test_that("wrap correctly wraps long lines", {
   expect_equal(wrap_format(15)("short line"), "short line")
 })
 
+# Ordinal formatter --------------------------------------------------------
+
 test_that("ordinal format", {
   expect_equal(ordinal(1), "1st")
   expect_equal(ordinal(2), "2nd")
@@ -85,6 +109,45 @@ test_that("ordinal format", {
 test_that("ordinal format maintains order", {
   expect_equal(ordinal(c(21, 1, 11)), c("21st", "1st", "11th"))
 })
+
+# Unit formatter --------------------------------------------------------
+
+test_that("unit format", {
+  expect_equal(
+    unit_format(unit = "km", scale = 1e-3)(c(1e3, 2e3)),
+    c("1 km", "2 km")
+  )
+  expect_equal(
+    unit_format(unit = "ha", scale = 1e-4)(c(1e3, 2e3)),
+    c("0.1 ha", "0.2 ha")
+  )
+  expect_equal(
+    unit_format()(c(1e3, 2e3)),
+    c("1,000 m", "2,000 m")
+  )
+})
+
+# Percent formatter -------------------------------------------------------
+
+test_that("negative percents work", {
+  expect_equal(percent(-0.6), "-60%")
+})
+
+test_that("Single 0 gives 0%", {
+  expect_equal(percent(0), "0%")
+})
+
+# Dollar formatter --------------------------------------------------------
+
+test_that("negative comes before prefix", {
+  expect_equal(dollar(-1), "$-1")
+})
+
+test_that("missing values preserved", {
+  expect_equal(dollar(NA_real_), "$NA")
+})
+
+# Common tests --------------------------------------------------------
 
 test_that("formatters don't add extra spaces", {
   has_space <- function(x) any(grepl("\\s", x))
@@ -112,40 +175,4 @@ test_that("formats work with 0 length input", {
   expect_identical(percent_format()(x), expected)
   expect_identical(scientific_format()(x), expected)
   expect_identical(trans_format(identity)(x), expected)
-})
-
-test_that("unit format", {
-  expect_equal(
-    unit_format(unit = "km", scale = 1e-3)(c(1e3, 2e3)),
-    c("1 km", "2 km")
-  )
-  expect_equal(
-    unit_format(unit = "ha", scale = 1e-4)(c(1e3, 2e3)),
-    c("0.1 ha", "0.2 ha")
-  )
-  expect_equal(
-    unit_format()(c(1e3, 2e3)),
-    c("1,000 m", "2,000 m")
-  )
-})
-
-
-# Percent formatter -------------------------------------------------------
-
-test_that("negative percents work", {
-  expect_equal(percent(-0.6), "-60%")
-})
-
-test_that("Single 0 gives 0%", {
-  expect_equal(percent(0), "0%")
-})
-
-# Dollar formatter --------------------------------------------------------
-
-test_that("negative comes before prefix", {
-  expect_equal(dollar(-1), "$-1")
-})
-
-test_that("missing values preserved", {
-  expect_equal(dollar(NA_real_), "$NA")
 })


### PR DESCRIPTION
Consistent with the arguments introduced by `number_format()`