### PR TITLE
Free `only.loose` argument inside `extended_breaks()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # scales 0.5.0.9000
 
+* `extended_breaks()` no longer forces `labeling::extended` argument
+  `only.loose = FALSE` to allow for more flexible breaks specification 
+  (@dpseidel, #99).
+
 * Remove `plyr` and `dichromat` dependencies. `dichromat` is now suggested
  (@dpseidel, #118).  
 

--- a/R/breaks.r
+++ b/R/breaks.r
@@ -39,7 +39,7 @@ extended_breaks <- function(n = 5, ...) {
     }
 
     rng <- range(x)
-    labeling::extended(rng[1], rng[2], n, only.loose = FALSE, ...)
+    labeling::extended(rng[1], rng[2], n, ...)
   }
 }
 


### PR DESCRIPTION
Fixes #99 

As the default of `only.loose = FALSE` in `labeling::extended()`, it seemed unnecessary to expose it as a parameter to `extended_breaks()` but it is no longer forced to `FALSE`, fixing #99.