### PR TITLE
Adjust expand_range() so zero range scales respect mul and add

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # scales 0.5.0.9000
 
+* `expand_range()` arguments `mul` and `add` now affect scales with a range of 0
+   (@dpseidel, tidyverse/ggplot2#2281).
+
 * New function `modulus_trans()` implements the modulus transformation for positive
   and negative values (@dpseidel).
 

--- a/R/bounds.r
+++ b/R/bounds.r
@@ -228,7 +228,7 @@ expand_range <- function(range, mul = 0, add = 0, zero_width = 1) {
   if (is.null(range)) return()
 
   if (zero_range(range)) {
-    c(range[1] - zero_width / 2, range[1] + zero_width / 2)
+    range + c(-1, 1) * (zero_width * mul + add)
   } else {
     range + c(-1, 1) * (diff(range) * mul + add)
   }

--- a/R/bounds.r
+++ b/R/bounds.r
@@ -223,15 +223,12 @@ squish_infinite <- function(x, range = c(0, 1)) {
 #' @param add additive constant
 #' @param zero_width distance to use if range has zero width
 #' @export
-
 expand_range <- function(range, mul = 0, add = 0, zero_width = 1) {
   if (is.null(range)) return()
 
-  if (zero_range(range)) {
-    range + c(-1, 1) * (zero_width * mul + add)
-  } else {
-    range + c(-1, 1) * (diff(range) * mul + add)
-  }
+  width <- if (zero_range(range)) zero_width else diff(range)
+
+  range + c(-1, 1) * (width * mul + add)
 }
 
 #' Determine if range of vector is close to zero, with a specified tolerance

--- a/tests/testthat/test-bounds.r
+++ b/tests/testthat/test-bounds.r
@@ -82,7 +82,7 @@ test_that("scaling is possible with logical values", {
 
 test_that("expand_range respects mul and add values", {
   expect_equal(expand_range(c(1,1), mul = 0, add = 0.6), c(0.4, 1.6))
-  expect_equal(expand_range(c(1,1), mul = 1, add = 0.6), c(-0.1, 2.1))
+  expect_equal(expand_range(c(1,1), mul = 1, add = 0.6), c(-0.6, 2.6))
   expect_equal(expand_range(c(1,9), mul = 0, add = 2), c(-1, 11))
 })
 

--- a/tests/testthat/test-bounds.r
+++ b/tests/testthat/test-bounds.r
@@ -79,3 +79,10 @@ test_that("scaling is possible with logical values", {
   expect_equal(rescale(c(FALSE, TRUE)), c(0, 1))
   expect_equal(rescale_mid(c(FALSE, TRUE), mid = 0.5), c(0, 1))
 })
+
+test_that("expand_range respects mul and add values", {
+  expect_equal(expand_range(c(1,1), mul = 0, add = 0.6), c(0.4, 1.6))
+  expect_equal(expand_range(c(1,1), mul = 1, add = 0.6), c(-0.1, 2.1))
+  expect_equal(expand_range(c(1,9), mul = 0, add = 2), c(-1, 11))
+})
+


### PR DESCRIPTION
This seemed the most logical and minimal fix but if you have a different idea, let me know.  Previously in expand_range(), `zero_width` was divided in half and added or subtracted on either side of the axis tick, resulting (from defaults) in a range of 1 (so when the original issue poster called `geom_boxplot(width=0)` there was no padding). Now instead, `zero_width` functions as our `diff(range)` and the equation matches that of non-zero ranges, respecting `mul` and `add`. 

This fixes (the scales side of) the original issue (respecting `mul` and `add` parameters) but single ticket facets specifying a boxplot `width` ≥  than this range will still look tight. Looking into this further I found some weird bugs happening with the `width` argument to `geom_boxplot` and `geom_violin`. Will open a separate issue wherever appropriate once I have a better grasp on what's going on. 

Fixes tidyverse/ggplot2#2281. 

Does this deserve a news bullet for scales? What sorts of downstream tests should I run? Would those belong on this PR?