### PR TITLE
Make log_breaks work with very small ranges

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # scales 1.0.0.9000
 
+* `log_breaks()` provides usable breaks even with very small ranges
+  (@billdenney, #168)
+
 # scales 1.0.0
 
 ## New Features

--- a/R/breaks.r
+++ b/R/breaks.r
@@ -137,7 +137,7 @@ log_sub_breaks <- function(rng, n = 5, base = 10) {
     upper_end <- pmin(max(which(breaks <= base^rng[2])) + 1, length(breaks))
     breaks[lower_end:upper_end]
   } else {
-    extended_breaks(n=n)(base^rng)
+    extended_breaks(n = n)(base^rng)
   }
 }
 

--- a/R/breaks.r
+++ b/R/breaks.r
@@ -131,10 +131,14 @@ log_sub_breaks <- function(rng, n = 5, base = 10) {
       break
     }
   }
-  breaks <- sort(breaks)
-  lower_end <- pmax(min(which(base^rng[1] <= breaks)) - 1, 1)
-  upper_end <- pmin(max(which(breaks <= base^rng[2])) + 1, length(breaks))
-  breaks[lower_end:upper_end]
+  if (sum(relevant_breaks) >= (n - 2)) {
+    breaks <- sort(breaks)
+    lower_end <- pmax(min(which(base^rng[1] <= breaks)) - 1, 1)
+    upper_end <- pmin(max(which(breaks <= base^rng[2])) + 1, length(breaks))
+    breaks[lower_end:upper_end]
+  } else {
+    extended_breaks(n=n)(base^rng)
+  }
 }
 
 #' Pretty breaks on transformed scale.

--- a/tests/testthat/test-breaks-log.r
+++ b/tests/testthat/test-breaks-log.r
@@ -64,14 +64,22 @@ test_that("log_breaks arguments are forcely evaluated on each call #81", {
 })
 
 test_that("log_breaks with very small ranges fall back to extended_breaks", {
-  expect_equal(log_breaks(n = 5, base = 10)(c(2.001, 2.002)),
-               extended_breaks(n = 5)(c(2.001, 2.002)))
-  expect_equal(log_breaks(n = 5, base = 10)(c(0.95, 1.1)),
-               extended_breaks(n = 5)(c(0.95, 1.1)))
+  expect_equal(
+    log_breaks(n = 5, base = 10)(c(2.001, 2.002)),
+    extended_breaks(n = 5)(c(2.001, 2.002))
+  )
+  expect_equal(
+    log_breaks(n = 5, base = 10)(c(0.95, 1.1)),
+    extended_breaks(n = 5)(c(0.95, 1.1))
+  )
 
   # The switch to extended_breaks occurs at approximately the half-log point
-  expect_equal(log_breaks(n = 5, base = 10)(c(0.95, 2.9)),
-               extended_breaks(n = 5)(c(0.95, 2.9)))
-  expect_false(identical(log_breaks(n = 5, base = 10)(c(0.95, 3)),
-                         extended_breaks(n = 5)(c(0.95, 3))))
+  expect_equal(
+    log_breaks(n = 5, base = 10)(c(0.95, 2.9)),
+    extended_breaks(n = 5)(c(0.95, 2.9))
+  )
+  expect_false(identical(
+    log_breaks(n = 5, base = 10)(c(0.95, 3)),
+    extended_breaks(n = 5)(c(0.95, 3))
+  ))
 })

--- a/tests/testthat/test-breaks-log.r
+++ b/tests/testthat/test-breaks-log.r
@@ -62,3 +62,16 @@ test_that("log_breaks arguments are forcely evaluated on each call #81", {
   expect_equal(subfun1(1:1000), subfuns[[1]](1:1000))
   expect_equal(subfun2(1:1000), subfuns[[2]](1:1000))
 })
+
+test_that("log_breaks with very small ranges fall back to extended_breaks", {
+  expect_equal(log_breaks(n = 5, base = 10)(c(2.001, 2.002)),
+               extended_breaks(n = 5)(c(2.001, 2.002)))
+  expect_equal(log_breaks(n = 5, base = 10)(c(0.95, 1.1)),
+               extended_breaks(n = 5)(c(0.95, 1.1)))
+
+  # The switch to extended_breaks occurs at approximately the half-log point
+  expect_equal(log_breaks(n = 5, base = 10)(c(0.95, 2.9)),
+               extended_breaks(n = 5)(c(0.95, 2.9)))
+  expect_false(identical(log_breaks(n = 5, base = 10)(c(0.95, 3)),
+                         extended_breaks(n = 5)(c(0.95, 3))))
+})


### PR DESCRIPTION
Fix #168 