### PR TITLE
Fix R6 inheritance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # scales 1.0.0.9000
 
+* `ContinuousRange` and `DiscreteRange` methods now properly inherit and are fully
+  mutable (@dpseidel).
+
 # scales 1.0.0
 
 ## New Features

--- a/R/range.r
+++ b/R/range.r
@@ -17,7 +17,7 @@ DiscreteRange <- R6::R6Class(
   inherit = Range,
   list(
     train = function(x, drop = FALSE) {
-      self$range <- train_discrete(x, range, drop)
+      self$range <- train_discrete(x, self$range, drop)
     },
     reset = function() self$range <- NULL
   )
@@ -27,7 +27,7 @@ ContinuousRange <- R6::R6Class(
   "ContinuousRange",
   inherit = Range,
   list(
-    train = function(x) self$range <- train_continuous(x, range),
+    train = function(x) self$range <- train_continuous(x, self$range),
     reset = function() self$range <- NULL
   )
 )

--- a/R/range.r
+++ b/R/range.r
@@ -14,7 +14,7 @@ Range <- R6::R6Class("Range", list(
 
 DiscreteRange <- R6::R6Class(
   "DiscreteRange",
-  inherit = "Range",
+  inherit = Range,
   list(
     train = function(x, drop = FALSE) {
       self$range <- train_discrete(x, range, drop)
@@ -25,7 +25,7 @@ DiscreteRange <- R6::R6Class(
 
 ContinuousRange <- R6::R6Class(
   "ContinuousRange",
-  inherit = "Range",
+  inherit = Range,
   list(
     train = function(x) self$range <- train_continuous(x, range),
     reset = function() self$range <- NULL

--- a/tests/testthat/test-range.r
+++ b/tests/testthat/test-range.r
@@ -1,5 +1,22 @@
 context("Ranges")
 
+test_that("R6 inheritance works", {
+  expect_error(ContinuousRange$new(), NA)
+  expect_error(DiscreteRange$new(), NA)
+  expect_true(R6::is.R6(ContinuousRange$new()))
+  expect_true(R6::is.R6(DiscreteRange$new()))
+})
+
+test_that("Mutable ranges work", {
+ x <- ContinuousRange$new()
+ x$train(c(-1, 45, 10))
+ expect_equal(x$range, c(-1, 45))
+ x$train(c(1000))
+ expect_equal(x$range, c(-1, 1000))
+ x$reset()
+ expect_equal(x$range, NULL)
+})
+
 test_that("starting with NULL always returns new", {
   expect_equal(discrete_range(NULL, 1:3), 1:3)
   expect_equal(discrete_range(NULL, 3:1), 1:3)

--- a/tests/testthat/test-range.r
+++ b/tests/testthat/test-range.r
@@ -8,13 +8,13 @@ test_that("R6 inheritance works", {
 })
 
 test_that("Mutable ranges work", {
- x <- ContinuousRange$new()
- x$train(c(-1, 45, 10))
- expect_equal(x$range, c(-1, 45))
- x$train(c(1000))
- expect_equal(x$range, c(-1, 1000))
- x$reset()
- expect_equal(x$range, NULL)
+  x <- ContinuousRange$new()
+  x$train(c(-1, 45, 10))
+  expect_equal(x$range, c(-1, 45))
+  x$train(c(1000))
+  expect_equal(x$range, c(-1, 1000))
+  x$reset()
+  expect_equal(x$range, NULL)
 })
 
 test_that("starting with NULL always returns new", {

--- a/tests/testthat/test-range.r
+++ b/tests/testthat/test-range.r
@@ -15,6 +15,14 @@ test_that("Mutable ranges work", {
   expect_equal(x$range, c(-1, 1000))
   x$reset()
   expect_equal(x$range, NULL)
+
+  x <- DiscreteRange$new()
+  x$train(factor(letters[1:3]))
+  expect_equal(x$range, c("a", "b", "c"))
+  x$train(factor("a", "h"))
+  expect_equal(x$range, c("a", "b", "c", "h"))
+  x$reset()
+  expect_equal(x$range, NULL)
 })
 
 test_that("starting with NULL always returns new", {


### PR DESCRIPTION
In trying to covert ggplot2 to use scales exported `Range` objects (tidyverse/ggplot2#2710), I realized that the R6 inheritance was broken. This PR fixes that. Unfortunately this likely means that conversion in ggplot2 needs to wait until the next scales release.