### PR TITLE
preserve element names in `alpha()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,8 @@
   Interpolation will still be used if there are more factor levels than
   available colors, and a warning will be emitted in that case (@jcheng5, #191).
 
+* `alpha()` preserve element names (@wibeasley, #195)
+
 # scales 1.0.0
 
 ## New Features

--- a/R/colour-manip.r
+++ b/R/colour-manip.r
@@ -50,8 +50,6 @@ muted <- function(colour, l=30, c=70) col2hcl(colour, l = l, c = c)
 #' alpha("red", 0.1)
 #' alpha(colours(), 0.5)
 #' alpha("red", seq(0, 1, length.out = 10))
-#' alpha(c(`1` = "gold", `2` = "lightgray", `3` = "#cd7f32"), .5)
-#' alpha(c(first = "gold", second = "lightgray", third = "#cd7f32"), .5)
 #' alpha(c("first" = "gold", "second" = "lightgray", "third" = "#cd7f32"), .5)
 alpha <- function(colour, alpha = NA) {
   col <- grDevices::col2rgb(colour, TRUE) / 255

--- a/R/colour-manip.r
+++ b/R/colour-manip.r
@@ -50,9 +50,9 @@ muted <- function(colour, l=30, c=70) col2hcl(colour, l = l, c = c)
 #' alpha("red", 0.1)
 #' alpha(colours(), 0.5)
 #' alpha("red", seq(0, 1, length.out = 10))
-#' alpha(c(`1`="gold", `2`="lightgray", `3`="#cd7f32"), .5)
-#' alpha(c(first="gold", second="lightgray", third="#cd7f32"), .5)
-#' alpha(c("first"="gold", "second"="lightgray", "third"="#cd7f32"), .5)
+#' alpha(c(`1` = "gold", `2` = "lightgray", `3` = "#cd7f32"), .5)
+#' alpha(c(first = "gold", second = "lightgray", third = "#cd7f32"), .5)
+#' alpha(c("first" = "gold", "second" = "lightgray", "third" = "#cd7f32"), .5)
 alpha <- function(colour, alpha = NA) {
   col <- grDevices::col2rgb(colour, TRUE) / 255
 

--- a/R/colour-manip.r
+++ b/R/colour-manip.r
@@ -50,6 +50,9 @@ muted <- function(colour, l=30, c=70) col2hcl(colour, l = l, c = c)
 #' alpha("red", 0.1)
 #' alpha(colours(), 0.5)
 #' alpha("red", seq(0, 1, length.out = 10))
+#' alpha(c(`1`="gold", `2`="lightgray", `3`="#cd7f32"), .5)
+#' alpha(c(first="gold", second="lightgray", third="#cd7f32"), .5)
+#' alpha(c("first"="gold", "second"="lightgray", "third"="#cd7f32"), .5)
 alpha <- function(colour, alpha = NA) {
   col <- grDevices::col2rgb(colour, TRUE) / 255
 
@@ -68,6 +71,7 @@ alpha <- function(colour, alpha = NA) {
 
   new_col <- grDevices::rgb(col[1, ], col[2, ], col[3, ], alpha)
   new_col[is.na(colour)] <- NA
+  names(new_col) <- names(colour)
   new_col
 }
 

--- a/man/alpha.Rd
+++ b/man/alpha.Rd
@@ -21,7 +21,5 @@ Vectorised in both colour and alpha.
 alpha("red", 0.1)
 alpha(colours(), 0.5)
 alpha("red", seq(0, 1, length.out = 10))
-alpha(c(`1` = "gold", `2` = "lightgray", `3` = "#cd7f32"), .5)
-alpha(c(first = "gold", second = "lightgray", third = "#cd7f32"), .5)
 alpha(c("first" = "gold", "second" = "lightgray", "third" = "#cd7f32"), .5)
 }

--- a/man/alpha.Rd
+++ b/man/alpha.Rd
@@ -21,4 +21,7 @@ Vectorised in both colour and alpha.
 alpha("red", 0.1)
 alpha(colours(), 0.5)
 alpha("red", seq(0, 1, length.out = 10))
+alpha(c(`1`="gold", `2`="lightgray", `3`="#cd7f32"), .5)
+alpha(c(first="gold", second="lightgray", third="#cd7f32"), .5)
+alpha(c("first"="gold", "second"="lightgray", "third"="#cd7f32"), .5)
 }

--- a/man/alpha.Rd
+++ b/man/alpha.Rd
@@ -21,7 +21,7 @@ Vectorised in both colour and alpha.
 alpha("red", 0.1)
 alpha(colours(), 0.5)
 alpha("red", seq(0, 1, length.out = 10))
-alpha(c(`1`="gold", `2`="lightgray", `3`="#cd7f32"), .5)
-alpha(c(first="gold", second="lightgray", third="#cd7f32"), .5)
-alpha(c("first"="gold", "second"="lightgray", "third"="#cd7f32"), .5)
+alpha(c(`1` = "gold", `2` = "lightgray", `3` = "#cd7f32"), .5)
+alpha(c(first = "gold", second = "lightgray", third = "#cd7f32"), .5)
+alpha(c("first" = "gold", "second" = "lightgray", "third" = "#cd7f32"), .5)
 }

--- a/tests/testthat/test-alpha.r
+++ b/tests/testthat/test-alpha.r
@@ -31,11 +31,10 @@ test_that("col values recycled to match alpha", {
 })
 
 test_that("preserves element names", {
-  expect_equal(c("first", "second", "third"), names(alpha(c("first" = "gold", "second" = "lightgray", "third" = "#cd7f32"), .5)))   # quoted
-  expect_equal(as.character(1:3)            , names(alpha(c("1"     = "gold", "2"      = "lightgray", "3"     = "#cd7f32"), .5)))   # numeric characters
-
-  expect_equal(c(""     , "second", "third"), names(alpha(c(          "gold", second   = "lightgray", third   = "#cd7f32"), .5)))   # first element name is missing
-  expect_equal(c("first", "second", ""     ), names(alpha(c(first   = "gold", second   = "lightgray",           "#cd7f32"), .5)))   # last element name is missing
+  expect_equal(
+    c("first", "second", "third"),
+    names(alpha(c("first" = "gold", "second" = "lightgray", "third" = "#cd7f32"), .5))
+  )
 })
 
 

--- a/tests/testthat/test-alpha.r
+++ b/tests/testthat/test-alpha.r
@@ -31,15 +31,11 @@ test_that("col values recycled to match alpha", {
 })
 
 test_that("preserves element names", {
-  expect_equal(c("first", "second", "third"), names(alpha(c(first   = "gold", second   = "lightgray", third   = "#cd7f32"), .5)))   # not quoted
   expect_equal(c("first", "second", "third"), names(alpha(c("first" = "gold", "second" = "lightgray", "third" = "#cd7f32"), .5)))   # quoted
   expect_equal(as.character(1:3)            , names(alpha(c("1"     = "gold", "2"      = "lightgray", "3"     = "#cd7f32"), .5)))   # numeric characters
-  expect_equal(as.character(1:3)            , names(alpha(c(`1`     = "gold", `2`      = "lightgray", `3`     = "#cd7f32"), .5)))   # in backticks
 
   expect_equal(c(""     , "second", "third"), names(alpha(c(          "gold", second   = "lightgray", third   = "#cd7f32"), .5)))   # first element name is missing
-  expect_equal(c("first", ""      , "third"), names(alpha(c(first   = "gold",            "lightgray", third   = "#cd7f32"), .5)))   # middle element name is missing
   expect_equal(c("first", "second", ""     ), names(alpha(c(first   = "gold", second   = "lightgray",           "#cd7f32"), .5)))   # last element name is missing
-  expect_equal(c("NULL" , "second", ""     ), names(alpha(c(NULL    = "gold", second   = "lightgray",           "#cd7f32"), .5)))   # last element looks like 'NULL', but is really a character
 })
 
 

--- a/tests/testthat/test-alpha.r
+++ b/tests/testthat/test-alpha.r
@@ -29,3 +29,22 @@ test_that("col values recycled to match alpha", {
 
   expect_equal(alphas, reds_alpha)
 })
+
+test_that("preserves element names", {
+  expect_equal(c("first", "second", "third"), names(alpha(c(first   = "gold", second   = "lightgray", third   = "#cd7f32"), .5)))   # not quoted
+  expect_equal(c("first", "second", "third"), names(alpha(c("first" = "gold", "second" = "lightgray", "third" = "#cd7f32"), .5)))   # quoted
+  expect_equal(as.character(1:3)            , names(alpha(c("1"     = "gold", "2"      = "lightgray", "3"     = "#cd7f32"), .5)))   # numeric characters
+  expect_equal(as.character(1:3)            , names(alpha(c(`1`     = "gold", `2`      = "lightgray", `3`     = "#cd7f32"), .5)))   # in backticks
+
+  expect_equal(c(""     , "second", "third"), names(alpha(c(          "gold", second   = "lightgray", third   = "#cd7f32"), .5)))   # first element name is missing
+  expect_equal(c("first", ""      , "third"), names(alpha(c(first   = "gold",            "lightgray", third   = "#cd7f32"), .5)))   # middle element name is missing
+  expect_equal(c("first", "second", ""     ), names(alpha(c(first   = "gold", second   = "lightgray",           "#cd7f32"), .5)))   # last element name is missing
+  expect_equal(c("NULL" , "second", ""     ), names(alpha(c(NULL    = "gold", second   = "lightgray",           "#cd7f32"), .5)))   # last element looks like 'NULL', but is really a character
+})
+
+
+test_that("doesn't add element names", {
+  pinks <- c("deeppink", "hotpink", "lightpink")
+
+  expect_null(names(alpha(pinks, NA)))
+})


### PR DESCRIPTION
The `alpha()` function now preserves names on the elements.  I followed the approach used earlier in the file for `col2hcl()`.

https://github.com/r-lib/scales/blob/51547d6865f61f8cc0239063bacc619dce8a35b6/R/colour-manip.r#L26

A common use case for me is when I create palette to pass to the `values` parameter of `ggplot2::scales_color_manual()` and `ggplot2::scales_fill_manual()`.  Like the [chapter 5 scatterplots here](
https://github.com/OuhscBbmc/DeSheaToothakerIntroStats/blob/master/thumbnails/thumbnails.md) (and  countless people before me), the scatterpoints are darker around the edges, but translucent in the center.  I need explicit vector names to force colors to be consistent across plots, even if a factor level is missing.

![image](https://user-images.githubusercontent.com/1372890/51051987-06d13980-159b-11e9-9212-bfa00820ffc3.png)

Instead of replicating the rgb components like:
```r
palette_dark  <- c("FALSE"="#3288BD"  , "TRUE"="#D53E4F"  ) # http://colrd.com/palette/18893/
palette_light <- c("FALSE"="#3288BDAA", "TRUE"="#D53E4FAA") 
```

It would be nice to reuse the palette (especially if wasn't defined immediately above):
```r
palette_dark  <- c("FALSE"="#3288BD", "TRUE"="#D53E4F") 
palette_light <- scales::alpha(palette_dark, .5)
```