### PR TITLE
Add n argument to the function returned by the breaks constructors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,10 @@
   palettes. Instead, it attempts to assign a palette color to each factor level.
   Interpolation will still be used if there are more factor levels than
   available colors, and a warning will be emitted in that case (@jcheng5, #191).
+  
+* The build in breaks functions now return a function that takes both a range 
+  and a desired number of breaks, making it possible to overwrite the defaults
+  number of desired breaks given in the constructor call (@thomasp85).
 
 # scales 1.0.0
 

--- a/R/breaks.r
+++ b/R/breaks.r
@@ -11,7 +11,8 @@
 #' pretty_breaks()(as.Date(c("2008-01-01", "2090-01-01")))
 pretty_breaks <- function(n = 5, ...) {
   force_all(n, ...)
-  function(x) {
+  n_default <- n
+  function(x, n = n_default) {
     breaks <- pretty(x, n, ...)
     names(breaks) <- attr(breaks, "labels")
     breaks
@@ -32,7 +33,8 @@ pretty_breaks <- function(n = 5, ...) {
 #' extended_breaks()(1:10)
 #' extended_breaks()(1:100)
 extended_breaks <- function(n = 5, ...) {
-  function(x) {
+  n_default <- n
+  function(x, n = n_default) {
     x <- x[is.finite(x)]
     if (length(x) == 0) {
       return(numeric())
@@ -56,7 +58,8 @@ extended_breaks <- function(n = 5, ...) {
 #' log_breaks()(c(1761, 8557))
 log_breaks <- function(n = 5, base = 10) {
   force_all(n, base)
-  function(x) {
+  n_default = n
+  function(x, n = n_default) {
     rng <- log(range(x, na.rm = TRUE), base = base)
     min <- floor(rng[1])
     max <- ceiling(rng[2])
@@ -160,7 +163,8 @@ trans_breaks <- function(trans, inv, n = 5, ...) {
   trans <- match.fun(trans)
   inv <- match.fun(inv)
   force_all(n, ...)
-  function(x) {
+  n_default <- n
+  function(x, n = n_default) {
     inv(pretty(trans(x), n, ...))
   }
 }


### PR DESCRIPTION
This PR modifies the function returned from the different breaks constructors to allow changing `n` after the constructor call. The value of the `n` argument in the constructor call will be used as a default for the `n` argument in the returned functions, meaning that no code should break with this addition.

This change is necessary in order to allow direct changing of desired break frequency in the `scale_*` functions in ggplot2