### PR TITLE
latex doesn't like unicode character for >=

### DIFF
--- a/R/formatter.r
+++ b/R/formatter.r
@@ -15,8 +15,8 @@
 #' specified `accuracy`, to add custom `suffix` and `prefix` and to specify
 #' `decimal.mark` and `big.mark`.
 #'
-#' `number_si()` gives limited SI unit labels: "K" for values ≥ 10e3, "
-#' M" for ≥ 10e6, "B" for ≥ 10e9, and "T" for ≥ 10e12.
+#' `number_si()` gives limited SI unit labels: "K" for values \eqn{\ge} 10e3, "
+#' M" for \eqn{\ge} 10e6, "B" for \eqn{\ge} 10e9, and "T" for \eqn{\ge} 10e12.
 #' It respects all arguments except `scale` which is set internally.
 #'
 #' @return `*_format()` returns a function with single parameter

--- a/man/number_format.Rd
+++ b/man/number_format.Rd
@@ -89,8 +89,8 @@ All formatters allow you to re-\code{scale} (multiplicatively), to round to
 specified \code{accuracy}, to add custom \code{suffix} and \code{prefix} and to specify
 \code{decimal.mark} and \code{big.mark}.
 
-\code{number_si()} gives limited SI unit labels: "K" for values ≥ 10e3, "
-M" for ≥ 10e6, "B" for ≥ 10e9, and "T" for ≥ 10e12.
+\code{number_si()} gives limited SI unit labels: "K" for values \eqn{\ge} 10e3, "
+M" for \eqn{\ge} 10e6, "B" for \eqn{\ge} 10e9, and "T" for \eqn{\ge} 10e12.
 It respects all arguments except \code{scale} which is set internally.
 }
 \examples{


### PR DESCRIPTION
There seems to be an error related to building the PDF manual causing the following PRs to fail:

-  #198 
- #197 
- #195 

The error is:
```
LaTeX errors found:
! Package inputenc Error: Unicode char ≥ (U+2265)
(inputenc)                not set up for use with LaTeX.
```

which is caused by the use of the `≥` symbol in the docs for `number_format()`. I've changed the offending symbol.