### PR TITLE
Add exponent and exact_zero argument to scientific_format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false
 cache: packages
 
 r:
-- 3.1
 - 3.2
 - 3.3
 - oldrel

--- a/R/formatter.r
+++ b/R/formatter.r
@@ -486,24 +486,23 @@ scientific <- function(x, digits = 3, scale = 1, prefix = "", suffix = "",
  # restore NAs from input vector
  ret[is.na(x)] <- NA
 
- # Replace 0 values with "0" if exact_zero mode
- if(exact_zero){
-   index_zero <- which(x == 0)
-   ret[index_zero] <- "0"
- }
+  # Replace 0 values with "0" if exact_zero mode
+  if(exact_zero){
+    index_zero <- which(x == 0)
+    ret[index_zero] <- "0"
+  }
 
   # if 10 exponent (10^x) mode
   exponent <- match.arg(exponent)
   if(exponent == "10"){
-    ret <- gsub("e", " %*% 10^{", ret)   # Change from e to * 10^ style
-    ret <- gsub("{-0", "{-", ret, fixed = TRUE)
-    ret <- gsub("{+", "{", ret, fixed = TRUE)
-    ret <- gsub("{0", "{", ret, fixed = TRUE)
-    ret <- paste(ret, "}",sep = "")
-    parse(text=ret)
-  } else{
-    ret
+    ret <- gsub("e", " %*% 10^", ret)   # Change from e to * 10^ style
+    ret <- gsub("e", " %*% 10^", ret)   # Change from e to * 10^ style
+    ret <- gsub("-0", "-", ret, fixed = TRUE)
+    ret <- gsub("+", "", ret, fixed = TRUE)
+    ret <- parse(text=ret)
   }
+
+  ret
 }
 
 #' Ordinal formatter: add ordinal suffixes (-st, -nd, -rd, -th) to numbers.

--- a/man/scientific_format.Rd
+++ b/man/scientific_format.Rd
@@ -6,15 +6,17 @@
 \title{Scientific formatter.}
 \usage{
 scientific_format(digits = 3, scale = 1, prefix = "", suffix = "",
-  decimal.mark = ".", trim = TRUE, ...)
+  decimal.mark = ".", trim = TRUE, exponent = c("e", "10"),
+  exact_zero = FALSE, ...)
 
 scientific(x, digits = 3, scale = 1, prefix = "", suffix = "",
-  decimal.mark = ".", trim = TRUE, ...)
+  decimal.mark = ".", trim = TRUE, exponent = c("e", "10"),
+  exact_zero = FALSE, ...)
 }
 \arguments{
 \item{digits}{Number of significant digits to show.}
 
-\item{scale}{A scaling factor: \code{x} will be multiply by \code{scale} before
+\item{scale}{A scaling factor: x will be multiply by scale before
 formating (useful if the underlying data is on another scale,
 e.g. for computing percentages or thousands).}
 
@@ -23,15 +25,19 @@ e.g. for computing percentages or thousands).}
 \item{decimal.mark}{The character to be used to indicate the numeric
 decimal point.}
 
-\item{trim}{Logical, if \code{FALSE}, values are right-justified to a common
+\item{trim}{Logical, if FALSE, values are right-justified to a common
 width (see \code{\link[base:format]{base::format()}}).}
+
+\item{exponent}{The character to be used to xponential notation. Valid values are "e" and "10".}
+
+\item{exact_zero}{Logical, if FALSE, 0 value is also shown like 0e+00}
 
 \item{...}{Other arguments passed on to \code{\link[base:format]{base::format()}}.}
 
 \item{x}{A numeric vector to format.}
 }
 \value{
-A function with single parameter \code{x}, a numeric vector, that
+A function with single parameter x, a numeric vector, that
 returns a character vector.
 }
 \description{


### PR DESCRIPTION
## Summary
The notation with 10 as a power index is [often discussed](https://stackoverflow.com/questions/10762287/how-can-i-format-axis-labels-with-exponents-with-ggplot2-and-scales).
Therefore, I thought it is useful to include this notation in `scales` package and implemented it.

## Example
```r
> scientific(1:10)
 [1] "1e+00" "2e+00" "3e+00" "4e+00" "5e+00" "6e+00" "7e+00" "8e+00" "9e+00" "1e+01"

> scientific(0:10, exponent="10", exact_zero = FALSE)
expression(0 %*% 10^00, 1 %*% 10^00, 2 %*% 10^00, 3 %*% 10^00, 
    4 %*% 10^00, 5 %*% 10^00, 6 %*% 10^00, 7 %*% 10^00, 8 %*% 10^00, 
    9 %*% 10^00, 1 %*% 10^01)

> scientific(0:10, exponent="10", exact_zero = TRUE)
expression(0, 1 %*% 10^00, 2 %*% 10^00, 3 %*% 10^00, 4 %*% 10^00, 
    5 %*% 10^00, 6 %*% 10^00, 7 %*% 10^00, 8 %*% 10^00, 9 %*% 10^00, 
    1 %*% 10^01)
```