### PR TITLE
Handle NA colors correctly in colour_ramp().

### DIFF
--- a/R/colour-ramp.R
+++ b/R/colour-ramp.R
@@ -55,7 +55,9 @@ colour_ramp <- function(colors, na.color = NA, alpha = TRUE) {
   u_interp <- stats::approxfun(x_in, lab_in[, 2])
   v_interp <- stats::approxfun(x_in, lab_in[, 3])
 
-  if (!alpha || all(lab_in[, 4] == 1)) {
+  # need to excludes all NAs inside all(), because all(NA) == NA,
+  # but all(numeric(0)) == TRUE (which is appropriate here)
+  if (!isTRUE(alpha) || all(lab_in[, 4][!is.na(lab_in[, 4])] == 1)) {
     alpha_interp <- function(x) NULL
   } else {
     alpha_interp <- stats::approxfun(x_in, lab_in[, 4])

--- a/tests/testthat/test-colour-ramp.R
+++ b/tests/testthat/test-colour-ramp.R
@@ -41,3 +41,11 @@ test_that("Interpolation works from color without to color with alpha channel", 
     "#1234AB80"
   )
 })
+
+test_that("NAs are ignored in color interpolation", {
+  x <- seq(0, 1, length = 5)
+  expect_identical(
+    colour_ramp(c("red", "blue"))(x),
+    colour_ramp(c("red", NA, "blue"))(x)
+  )
+})


### PR DESCRIPTION
This closes #241.

``` r
library(scales)

ramp <- colour_ramp(c("red", NA, "blue"))
show_col(ramp(seq(0, 1, length = 12)))
```

![](https://i.imgur.com/n2WhMz4.png)

<sup>Created on 2019-12-17 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>