### PR TITLE
keep grDevices-style NA handling in colour_ramp

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ BugReports: https://github.com/r-lib/scales/issues
 Depends: 
     R (>= 3.2)
 Imports: 
-    farver (>= 2.0.0),
+    farver (>= 2.0.3),
     labeling,
     munsell (>= 0.5),
     R6,

--- a/R/colour-ramp.R
+++ b/R/colour-ramp.R
@@ -48,7 +48,8 @@ colour_ramp <- function(colors, na.color = NA, alpha = TRUE) {
 
   # farver is not currently case insensitive, but col2rgb() is
   colors <- tolower(colors)
-  lab_in <- farver::decode_colour(colors, alpha = TRUE, to = "lab")
+  lab_in <- farver::decode_colour(colors, alpha = TRUE, to = "lab",
+                                  na_value = "transparent")
 
   x_in <- seq(0, 1, length.out = length(colors))
   l_interp <- stats::approxfun(x_in, lab_in[, 1])


### PR DESCRIPTION
Fix #241 This PR restores the old behaviour of treating NA input as `'transparent'` when creating a `colour_ramp()`