### PR TITLE
Fix direction = -1 functionality for `hue_pal` (#252)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # scales (development version)
 
+* `hue_pal` now correctly inverts color palettes when `direction = -1` (@dpseidel, #252). 
+
 # scales 1.1.0
 
 * Axis breaks and labels have a new naming scheme: functions that generate

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # scales (development version)
 
-* `hue_pal` now correctly inverts color palettes when `direction = -1` (@dpseidel, #252). 
+* `hue_pal()` now correctly inverts color palettes when `direction = -1` 
+  (@dpseidel, #252). 
 
 # scales 1.1.0
 

--- a/R/pal-hue.r
+++ b/R/pal-hue.r
@@ -36,10 +36,15 @@ hue_pal <- function(h = c(0, 360) + 15, c = 100, l = 65, h.start = 0, direction 
       h[2] <- h[2] - 360 / n
     }
 
-    rotate <- function(x) (x + h.start) %% 360 * direction
-    hues <- rotate(seq(h[1], h[2], length.out = n))
-
+    hues <- seq(h[1], h[2], length.out = n)
     hcl <- cbind(hues, c, l)
-    farver::encode_colour(hcl, from = "hcl")
+
+    pal <- farver::encode_colour(hcl, from = "hcl")
+
+    if (direction == -1) {
+      pal <- rev(pal)
+    }
+
+    return(pal)
   }
 }

--- a/R/pal-hue.r
+++ b/R/pal-hue.r
@@ -42,9 +42,9 @@ hue_pal <- function(h = c(0, 360) + 15, c = 100, l = 65, h.start = 0, direction 
     pal <- farver::encode_colour(hcl, from = "hcl")
 
     if (direction == -1) {
-      pal <- rev(pal)
+      rev(pal)
+    } else {
+      pal
     }
-
-    return(pal)
   }
 }

--- a/tests/testthat/test-pal-hue.r
+++ b/tests/testthat/test-pal-hue.r
@@ -13,4 +13,10 @@ test_that("hue_pal arguments are forcely evaluated on each call #81", {
   expect_equal(col2(1), colours[[2]](1))
 })
 
+test_that("hue_pal respects direction argument #252", {
+  col1 <- hue_pal()
+  col2 <- hue_pal(direction = -1)
 
+  expect_equal(col1(3), rev(col2(3)))
+  expect_equal(col1(9), rev(col2(9)))
+})


### PR DESCRIPTION
scales 1.1.0 replaced `grDevices::hcl` with `farver::encode_colour` breaking the `direction  = -1` functionality  for `hue_pal`. Original functionality relied upon parsing negative hue values. 

This new implementation matches our current handling of the direction argument in `brewer_pal` using the `rev` argument to simply reverse the palette returned when `direction = -1`.  This is different from the implementation used in scales 1.0.0 (see below) which returns colors from the opposite side of the color wheel, but I think this actually is more consistent with expected `direction = -1` behavior for discrete scales. 

#### `hue_pal(direction = 1)`

``` r
show_col(hue_pal(direction = 1)(4))
```

![](https://i.imgur.com/m0huMSj.png)

#### `hue_pal(direction = -1)`

scales 1.0.0 

``` r
show_col(hue_pal(direction = -1)(4))
```
![](https://i.imgur.com/A3J24HD.png)


scales 1.1.0

``` r
show_col(hue_pal(direction = -1)(4))
```

![](https://i.imgur.com/DWNNvWX.png)

scales 1.1.0.9000 (dpseidel/scales, patch_huepal)

![image](https://user-images.githubusercontent.com/16724456/73911935-18514780-4868-11ea-95b2-ae436acfca3a.png)


This PR addresses #252 