### PR TITLE
Allow functions for prefix and suffix; closes #262

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 # scales 1.1.1
 
+* `number()` and reliant label functions now allow functions for the prefix and 
+  suffix arguments (@dkahle, #262).
+
 * `breaks_width()` now handles `difftime`/`hms` objects (@bhogan-mitre, #244).
 
 * `hue_pal()` now correctly inverts color palettes when `direction = -1` 

--- a/R/label-number.r
+++ b/R/label-number.r
@@ -4,18 +4,16 @@
 #' [scientific][label_scientific] notation). `label_comma()` is a special case
 #' that inserts a comma every three digits.
 #'
-#' @return
-#' All `label_()` functions return a "labelling" function, i.e. a function that
-#' takes a vector `x` and returns a character vector of `length(x)` giving a
-#' label for each input value.
+#' @return All `label_()` functions return a "labelling" function, i.e. a
+#' function that takes a vector `x` and returns a character vector of
+#' `length(x)` giving a label for each input value.
 #'
 #' Labelling functions are designed to be used with the `labels` argument of
-#' ggplot2 scales. The examples demonstrate their use with x scales, but
-#' they work similarly for all scales, including those that generate legends
-#' rather than axes.
-#' @section Old interface:
-#' `number_format()`, `comma_format()`, and `comma()` are retired; please use
-#' `label_number()` and `label_comma()` instead.
+#' ggplot2 scales. The examples demonstrate their use with x scales, but they
+#' work similarly for all scales, including those that generate legends rather
+#' than axes.
+#' @section Old interface: `number_format()`, `comma_format()`, and `comma()`
+#'   are retired; please use `label_number()` and `label_comma()` instead.
 #' @param x A numeric vector to format.
 #' @param accuracy A number to round to. Use (e.g.) `0.01` to show 2 decimal
 #'   places of precision. If `NULL`, the default, uses a heuristic that should
@@ -26,12 +24,13 @@
 #' @param scale A scaling factor: `x` will be multiplied by `scale` before
 #'   formating. This is useful if the underlying data is very small or very
 #'   large.
-#' @param prefix,suffix Symbols to display before and after value.
+#' @param prefix,suffix Symbols to display before and after value or a function
+#'   returning symbols.
 #' @param big.mark Character used between every 3 digits to separate thousands.
-#' @param decimal.mark The character to be used to indicate the numeric
-#'   decimal point.
-#' @param trim Logical, if `FALSE`, values are right-justified to a common
-#'   width (see [base::format()]).
+#' @param decimal.mark The character to be used to indicate the numeric decimal
+#'   point.
+#' @param trim Logical, if `FALSE`, values are right-justified to a common width
+#'   (see [base::format()]).
 #' @param ... Other arguments passed on to [base::format()].
 #' @export
 #' @examples
@@ -49,6 +48,8 @@
 #' # You can use prefix and suffix for other types of display
 #' demo_continuous(c(32, 212), label = label_number(suffix = "\u00b0F"))
 #' demo_continuous(c(0, 100), label = label_number(suffix = "\u00b0C"))
+#' plus_prefix <- function(.) if (. > 0) "+" else ""
+#' demo_continuous(c(-10, 10), label = label_number(prefix = plus_prefix))
 label_number <- function(accuracy = NULL, scale = 1, prefix = "",
                           suffix = "", big.mark = " ", decimal.mark = ".",
                           trim = TRUE, ...) {
@@ -150,6 +151,9 @@ number <- function(x, accuracy = NULL, scale = 1, prefix = "",
   x <- round_any(x, accuracy / scale)
   nsmall <- -floor(log10(accuracy))
   nsmall <- min(max(nsmall, 0), 20)
+
+  if (is.function(prefix)) prefix <- vapply(x, prefix, character(1))
+  if (is.function(suffix)) suffix <- vapply(x, suffix, character(1))
 
   ret <- format(
     scale * x,

--- a/R/label-percent.R
+++ b/R/label-percent.R
@@ -4,6 +4,7 @@
 #' `percent()` and `percent_format()` are retired; please use `label_percent()`
 #' instead.
 #' @inherit number_format return params
+#' @param plus logical; if [TRUE], a plus symbol is prefixed to the percentage
 #' @export
 #' @family labels for continuous scales
 #' @examples
@@ -16,9 +17,29 @@
 #'   suffix = " %"
 #' )
 #' demo_continuous(c(0, .01), labels = french_percent)
+#'
+#' # Put plus signs on positive values
+#' demo_continuous(c(-.50, .50), labels = label_percent())
+#' demo_continuous(c(-.50, .50), labels = label_percent(plus = TRUE))
 label_percent <- function(accuracy = NULL, scale = 100, prefix = "",
                            suffix = "%", big.mark = " ", decimal.mark = ".",
-                           trim = TRUE, ...) {
+                           trim = TRUE, plus = FALSE, ...) {
+
+
+  if (!missing(plus)) {
+    stopifnot(is.logical(plus) && length(plus) == 1L)
+    if (!missing(prefix) & plus == TRUE)
+      warning("`prefix` and `plus = TRUE` both specified; `plus` takes precedence", call. = FALSE)
+
+    if (plus) {
+      prefix <- function(x) {
+        if (length(x) > 1) return(vapply(x, prefix, character(1)))
+        if (!is.na(x) && x > 0) "+" else ""
+      }
+    }
+  }
+
+
   number_format(
     accuracy = accuracy,
     scale = scale,
@@ -39,7 +60,21 @@ percent_format <- label_percent
 #' @rdname label_percent
 percent <- function(x, accuracy = NULL, scale = 100, prefix = "",
                     suffix = "%", big.mark = " ", decimal.mark = ".",
-                    trim = TRUE, ...) {
+                    trim = TRUE, plus = FALSE, ...) {
+
+  if (!missing(plus)) {
+    stopifnot(is.logical(plus) && length(plus) == 1L)
+    if (!missing(prefix) & plus == TRUE)
+      warning("`prefix` and `plus = TRUE` both specified; `plus` takes precedence", call. = FALSE)
+
+    if (plus) {
+      prefix <- function(x) {
+        if (length(x) > 1) return(vapply(x, prefix, character(1)))
+        if (!is.na(x) && x > 0) "+" else ""
+      }
+    }
+  }
+
   number(
     x = x,
     accuracy = accuracy,

--- a/man/label_date.Rd
+++ b/man/label_date.Rd
@@ -31,14 +31,14 @@ to UTC}
 \item{sep}{Separator to use when combining date formats into a single string.}
 }
 \value{
-All \code{label_()} functions return a "labelling" function, i.e. a function that
-takes a vector \code{x} and returns a character vector of \code{length(x)} giving a
-label for each input value.
+All \code{label_()} functions return a "labelling" function, i.e. a
+function that takes a vector \code{x} and returns a character vector of
+\code{length(x)} giving a label for each input value.
 
 Labelling functions are designed to be used with the \code{labels} argument of
-ggplot2 scales. The examples demonstrate their use with x scales, but
-they work similarly for all scales, including those that generate legends
-rather than axes.
+ggplot2 scales. The examples demonstrate their use with x scales, but they
+work similarly for all scales, including those that generate legends rather
+than axes.
 }
 \description{
 \code{label_date()} and \code{label_time()} label date/times using date/time format

--- a/man/label_dollar.Rd
+++ b/man/label_dollar.Rd
@@ -60,11 +60,11 @@ large.}
 
 \item{big.mark}{Character used between every 3 digits to separate thousands.}
 
-\item{decimal.mark}{The character to be used to indicate the numeric
-decimal point.}
+\item{decimal.mark}{The character to be used to indicate the numeric decimal
+point.}
 
-\item{trim}{Logical, if \code{FALSE}, values are right-justified to a common
-width (see \code{\link[base:format]{base::format()}}).}
+\item{trim}{Logical, if \code{FALSE}, values are right-justified to a common width
+(see \code{\link[base:format]{base::format()}}).}
 
 \item{negative_parens}{Display negative using parentheses?}
 
@@ -73,14 +73,14 @@ width (see \code{\link[base:format]{base::format()}}).}
 \item{x}{A numeric vector}
 }
 \value{
-All \code{label_()} functions return a "labelling" function, i.e. a function that
-takes a vector \code{x} and returns a character vector of \code{length(x)} giving a
-label for each input value.
+All \code{label_()} functions return a "labelling" function, i.e. a
+function that takes a vector \code{x} and returns a character vector of
+\code{length(x)} giving a label for each input value.
 
 Labelling functions are designed to be used with the \code{labels} argument of
-ggplot2 scales. The examples demonstrate their use with x scales, but
-they work similarly for all scales, including those that generate legends
-rather than axes.
+ggplot2 scales. The examples demonstrate their use with x scales, but they
+work similarly for all scales, including those that generate legends rather
+than axes.
 }
 \description{
 Format numbers as currency, rounding values to dollars or cents using

--- a/man/label_number.Rd
+++ b/man/label_number.Rd
@@ -79,15 +79,16 @@ Applied to rescaled data.}
 formating. This is useful if the underlying data is very small or very
 large.}
 
-\item{prefix, suffix}{Symbols to display before and after value.}
+\item{prefix, suffix}{Symbols to display before and after value or a function
+returning symbols.}
 
 \item{big.mark}{Character used between every 3 digits to separate thousands.}
 
-\item{decimal.mark}{The character to be used to indicate the numeric
-decimal point.}
+\item{decimal.mark}{The character to be used to indicate the numeric decimal
+point.}
 
-\item{trim}{Logical, if \code{FALSE}, values are right-justified to a common
-width (see \code{\link[base:format]{base::format()}}).}
+\item{trim}{Logical, if \code{FALSE}, values are right-justified to a common width
+(see \code{\link[base:format]{base::format()}}).}
 
 \item{...}{Other arguments passed on to \code{\link[base:format]{base::format()}}.}
 
@@ -96,14 +97,14 @@ width (see \code{\link[base:format]{base::format()}}).}
 \item{x}{A numeric vector to format.}
 }
 \value{
-All \code{label_()} functions return a "labelling" function, i.e. a function that
-takes a vector \code{x} and returns a character vector of \code{length(x)} giving a
-label for each input value.
+All \code{label_()} functions return a "labelling" function, i.e. a
+function that takes a vector \code{x} and returns a character vector of
+\code{length(x)} giving a label for each input value.
 
 Labelling functions are designed to be used with the \code{labels} argument of
-ggplot2 scales. The examples demonstrate their use with x scales, but
-they work similarly for all scales, including those that generate legends
-rather than axes.
+ggplot2 scales. The examples demonstrate their use with x scales, but they
+work similarly for all scales, including those that generate legends rather
+than axes.
 }
 \description{
 Use \code{label_number()} force decimal display of numbers (i.e. don't use
@@ -111,9 +112,8 @@ Use \code{label_number()} force decimal display of numbers (i.e. don't use
 that inserts a comma every three digits.
 }
 \section{Old interface}{
-
-\code{number_format()}, \code{comma_format()}, and \code{comma()} are retired; please use
-\code{label_number()} and \code{label_comma()} instead.
+ \code{number_format()}, \code{comma_format()}, and \code{comma()}
+are retired; please use \code{label_number()} and \code{label_comma()} instead.
 }
 
 \examples{
@@ -131,4 +131,6 @@ demo_continuous(c(0, 1e-6), labels = label_number(scale = 1e6))
 # You can use prefix and suffix for other types of display
 demo_continuous(c(32, 212), label = label_number(suffix = "\u00b0F"))
 demo_continuous(c(0, 100), label = label_number(suffix = "\u00b0C"))
+plus_prefix <- function(.) if (. > 0) "+" else ""
+demo_continuous(c(-10, 10), label = label_number(prefix = plus_prefix))
 }

--- a/man/label_number_si.Rd
+++ b/man/label_number_si.Rd
@@ -22,14 +22,14 @@ Applied to rescaled data.}
 \item{...}{Other arguments passed on to \code{\link[base:format]{base::format()}}.}
 }
 \value{
-All \code{label_()} functions return a "labelling" function, i.e. a function that
-takes a vector \code{x} and returns a character vector of \code{length(x)} giving a
-label for each input value.
+All \code{label_()} functions return a "labelling" function, i.e. a
+function that takes a vector \code{x} and returns a character vector of
+\code{length(x)} giving a label for each input value.
 
 Labelling functions are designed to be used with the \code{labels} argument of
-ggplot2 scales. The examples demonstrate their use with x scales, but
-they work similarly for all scales, including those that generate legends
-rather than axes.
+ggplot2 scales. The examples demonstrate their use with x scales, but they
+work similarly for all scales, including those that generate legends rather
+than axes.
 }
 \description{
 \code{number_si()} automatically scales and labels with the best SI prefix,

--- a/man/label_ordinal.Rd
+++ b/man/label_ordinal.Rd
@@ -57,14 +57,14 @@ Name gives suffix, and value specifies which numbers to match.}
 \item{x}{A numeric vector to format.}
 }
 \value{
-All \code{label_()} functions return a "labelling" function, i.e. a function that
-takes a vector \code{x} and returns a character vector of \code{length(x)} giving a
-label for each input value.
+All \code{label_()} functions return a "labelling" function, i.e. a
+function that takes a vector \code{x} and returns a character vector of
+\code{length(x)} giving a label for each input value.
 
 Labelling functions are designed to be used with the \code{labels} argument of
-ggplot2 scales. The examples demonstrate their use with x scales, but
-they work similarly for all scales, including those that generate legends
-rather than axes.
+ggplot2 scales. The examples demonstrate their use with x scales, but they
+work similarly for all scales, including those that generate legends rather
+than axes.
 }
 \description{
 Round values to integers and then display as ordinal values (e.g. 1st, 2nd,

--- a/man/label_parse.Rd
+++ b/man/label_parse.Rd
@@ -23,14 +23,14 @@ transformation - this makes it easier to use floating point numbers in
 mathematical expressions.}
 }
 \value{
-All \code{label_()} functions return a "labelling" function, i.e. a function that
-takes a vector \code{x} and returns a character vector of \code{length(x)} giving a
-label for each input value.
+All \code{label_()} functions return a "labelling" function, i.e. a
+function that takes a vector \code{x} and returns a character vector of
+\code{length(x)} giving a label for each input value.
 
 Labelling functions are designed to be used with the \code{labels} argument of
-ggplot2 scales. The examples demonstrate their use with x scales, but
-they work similarly for all scales, including those that generate legends
-rather than axes.
+ggplot2 scales. The examples demonstrate their use with x scales, but they
+work similarly for all scales, including those that generate legends rather
+than axes.
 }
 \description{
 \code{label_parse()} produces expression from strings by parsing them;

--- a/man/label_percent.Rd
+++ b/man/label_percent.Rd
@@ -14,6 +14,7 @@ label_percent(
   big.mark = " ",
   decimal.mark = ".",
   trim = TRUE,
+  plus = FALSE,
   ...
 )
 
@@ -25,6 +26,7 @@ percent_format(
   big.mark = " ",
   decimal.mark = ".",
   trim = TRUE,
+  plus = FALSE,
   ...
 )
 
@@ -37,6 +39,7 @@ percent(
   big.mark = " ",
   decimal.mark = ".",
   trim = TRUE,
+  plus = FALSE,
   ...
 )
 }
@@ -52,31 +55,35 @@ Applied to rescaled data.}
 formating. This is useful if the underlying data is very small or very
 large.}
 
-\item{prefix}{Symbols to display before and after value.}
+\item{prefix}{Symbols to display before and after value or a function
+returning symbols.}
 
-\item{suffix}{Symbols to display before and after value.}
+\item{suffix}{Symbols to display before and after value or a function
+returning symbols.}
 
 \item{big.mark}{Character used between every 3 digits to separate thousands.}
 
-\item{decimal.mark}{The character to be used to indicate the numeric
-decimal point.}
+\item{decimal.mark}{The character to be used to indicate the numeric decimal
+point.}
 
-\item{trim}{Logical, if \code{FALSE}, values are right-justified to a common
-width (see \code{\link[base:format]{base::format()}}).}
+\item{trim}{Logical, if \code{FALSE}, values are right-justified to a common width
+(see \code{\link[base:format]{base::format()}}).}
+
+\item{plus}{logical; if \link{TRUE}, a plus symbol is prefixed to the percentage}
 
 \item{...}{Other arguments passed on to \code{\link[base:format]{base::format()}}.}
 
 \item{x}{A numeric vector to format.}
 }
 \value{
-All \code{label_()} functions return a "labelling" function, i.e. a function that
-takes a vector \code{x} and returns a character vector of \code{length(x)} giving a
-label for each input value.
+All \code{label_()} functions return a "labelling" function, i.e. a
+function that takes a vector \code{x} and returns a character vector of
+\code{length(x)} giving a label for each input value.
 
 Labelling functions are designed to be used with the \code{labels} argument of
-ggplot2 scales. The examples demonstrate their use with x scales, but
-they work similarly for all scales, including those that generate legends
-rather than axes.
+ggplot2 scales. The examples demonstrate their use with x scales, but they
+work similarly for all scales, including those that generate legends rather
+than axes.
 }
 \description{
 Label percentages (2.5\%, 50\%, etc)
@@ -97,6 +104,10 @@ french_percent <- label_percent(
   suffix = " \%"
 )
 demo_continuous(c(0, .01), labels = french_percent)
+
+# Put plus signs on positive values
+demo_continuous(c(-.50, .50), labels = label_percent())
+demo_continuous(c(-.50, .50), labels = label_percent(plus = TRUE))
 }
 \seealso{
 Other labels for continuous scales: 

--- a/man/label_pvalue.Rd
+++ b/man/label_pvalue.Rd
@@ -30,8 +30,8 @@ difference between adjacent values.
 
 Applied to rescaled data.}
 
-\item{decimal.mark}{The character to be used to indicate the numeric
-decimal point.}
+\item{decimal.mark}{The character to be used to indicate the numeric decimal
+point.}
 
 \item{prefix}{A character vector of length 3 giving the prefixes to
 put in front of numbers. The default values are \code{c("<", "", ">")}
@@ -42,14 +42,14 @@ if \code{add_p} is \code{TRUE} and \code{c("p<", "p=", "p>")} if \code{FALSE}.}
 \item{x}{A numeric vector to format.}
 }
 \value{
-All \code{label_()} functions return a "labelling" function, i.e. a function that
-takes a vector \code{x} and returns a character vector of \code{length(x)} giving a
-label for each input value.
+All \code{label_()} functions return a "labelling" function, i.e. a
+function that takes a vector \code{x} and returns a character vector of
+\code{length(x)} giving a label for each input value.
 
 Labelling functions are designed to be used with the \code{labels} argument of
-ggplot2 scales. The examples demonstrate their use with x scales, but
-they work similarly for all scales, including those that generate legends
-rather than axes.
+ggplot2 scales. The examples demonstrate their use with x scales, but they
+work similarly for all scales, including those that generate legends rather
+than axes.
 }
 \description{
 Formatter for p-values, using "<" and ">" for p-values close to 0 and 1.

--- a/man/label_scientific.Rd
+++ b/man/label_scientific.Rd
@@ -46,25 +46,25 @@ large.}
 
 \item{prefix, suffix}{Symbols to display before and after value.}
 
-\item{decimal.mark}{The character to be used to indicate the numeric
-decimal point.}
+\item{decimal.mark}{The character to be used to indicate the numeric decimal
+point.}
 
-\item{trim}{Logical, if \code{FALSE}, values are right-justified to a common
-width (see \code{\link[base:format]{base::format()}}).}
+\item{trim}{Logical, if \code{FALSE}, values are right-justified to a common width
+(see \code{\link[base:format]{base::format()}}).}
 
 \item{...}{Other arguments passed on to \code{\link[base:format]{base::format()}}.}
 
 \item{x}{A numeric vector to format.}
 }
 \value{
-All \code{label_()} functions return a "labelling" function, i.e. a function that
-takes a vector \code{x} and returns a character vector of \code{length(x)} giving a
-label for each input value.
+All \code{label_()} functions return a "labelling" function, i.e. a
+function that takes a vector \code{x} and returns a character vector of
+\code{length(x)} giving a label for each input value.
 
 Labelling functions are designed to be used with the \code{labels} argument of
-ggplot2 scales. The examples demonstrate their use with x scales, but
-they work similarly for all scales, including those that generate legends
-rather than axes.
+ggplot2 scales. The examples demonstrate their use with x scales, but they
+work similarly for all scales, including those that generate legends rather
+than axes.
 }
 \description{
 Label numbers with scientific notation (e.g. 1e05, 1.5e-02)

--- a/man/label_wrap.Rd
+++ b/man/label_wrap.Rd
@@ -13,14 +13,14 @@ wrap_format(width)
 \item{width}{Number of characters per line.}
 }
 \value{
-All \code{label_()} functions return a "labelling" function, i.e. a function that
-takes a vector \code{x} and returns a character vector of \code{length(x)} giving a
-label for each input value.
+All \code{label_()} functions return a "labelling" function, i.e. a
+function that takes a vector \code{x} and returns a character vector of
+\code{length(x)} giving a label for each input value.
 
 Labelling functions are designed to be used with the \code{labels} argument of
-ggplot2 scales. The examples demonstrate their use with x scales, but
-they work similarly for all scales, including those that generate legends
-rather than axes.
+ggplot2 scales. The examples demonstrate their use with x scales, but they
+work similarly for all scales, including those that generate legends rather
+than axes.
 }
 \description{
 Uses \code{\link[=strwrap]{strwrap()}} to split long labels across multiple lines.

--- a/man/number.Rd
+++ b/man/number.Rd
@@ -30,17 +30,19 @@ Applied to rescaled data.}
 formating. This is useful if the underlying data is very small or very
 large.}
 
-\item{prefix}{Symbols to display before and after value.}
+\item{prefix}{Symbols to display before and after value or a function
+returning symbols.}
 
-\item{suffix}{Symbols to display before and after value.}
+\item{suffix}{Symbols to display before and after value or a function
+returning symbols.}
 
 \item{big.mark}{Character used between every 3 digits to separate thousands.}
 
-\item{decimal.mark}{The character to be used to indicate the numeric
-decimal point.}
+\item{decimal.mark}{The character to be used to indicate the numeric decimal
+point.}
 
-\item{trim}{Logical, if \code{FALSE}, values are right-justified to a common
-width (see \code{\link[base:format]{base::format()}}).}
+\item{trim}{Logical, if \code{FALSE}, values are right-justified to a common width
+(see \code{\link[base:format]{base::format()}}).}
 
 \item{...}{Other arguments passed on to \code{\link[base:format]{base::format()}}.}
 }

--- a/man/unit_format.Rd
+++ b/man/unit_format.Rd
@@ -29,21 +29,23 @@ Applied to rescaled data.}
 formating. This is useful if the underlying data is very small or very
 large.}
 
-\item{prefix}{Symbols to display before and after value.}
+\item{prefix}{Symbols to display before and after value or a function
+returning symbols.}
 
 \item{unit}{The units to append.}
 
 \item{sep}{The separator between the number and the unit label.}
 
-\item{suffix}{Symbols to display before and after value.}
+\item{suffix}{Symbols to display before and after value or a function
+returning symbols.}
 
 \item{big.mark}{Character used between every 3 digits to separate thousands.}
 
-\item{decimal.mark}{The character to be used to indicate the numeric
-decimal point.}
+\item{decimal.mark}{The character to be used to indicate the numeric decimal
+point.}
 
-\item{trim}{Logical, if \code{FALSE}, values are right-justified to a common
-width (see \code{\link[base:format]{base::format()}}).}
+\item{trim}{Logical, if \code{FALSE}, values are right-justified to a common width
+(see \code{\link[base:format]{base::format()}}).}
 
 \item{...}{Other arguments passed on to \code{\link[base:format]{base::format()}}.}
 }

--- a/tests/testthat/test-label-number.r
+++ b/tests/testthat/test-label-number.r
@@ -22,6 +22,14 @@ test_that("number format works correctly", {
   )
   expect_equal(number(c(1, 23)), c("1", "23"))
   expect_equal(number(c(1, 23), trim = FALSE), c(" 1", "23"))
+  expect_equal(
+    number(c(-1, 1), accuracy = 1, prefix = function(.) if (. > 0) "+" else ""),
+    c("-1", "+1")
+  )
+  expect_equal(
+    number(c(-1, 1), accuracy = 1, suffix = function(.) if (. > 0) "^" else "_"),
+    c("-1_", "1^")
+  )
 })
 
 test_that("number_format works with Inf", {

--- a/tests/testthat/test-label-percent.R
+++ b/tests/testthat/test-label-percent.R
@@ -23,3 +23,28 @@ test_that("default accuracy works for range of inputs", {
   expect_equal(percent(x), c("10%", "20%", "50%"))
   expect_equal(percent(x * 10), c("100%", "200%", "500%"))
 })
+
+test_that("plus works - percent()", {
+  expect_equal(
+    percent(c(-.25, .25), plus = TRUE),
+    c("-25%", "+25%")
+  )
+
+  expect_warning(
+    percent(c(-.25, .25), plus = TRUE, prefix = "$"),
+    "`prefix` and `plus = TRUE` both specified; `plus` takes precedence"
+  )
+})
+
+
+test_that("plus works - label_percent()", {
+  expect_equal(
+    label_percent(plus = TRUE)(c(-.25, .25)),
+    c("-25%", "+25%")
+  )
+
+  expect_warning(
+    label_percent(plus = TRUE, prefix = "$")(c(-.25, .25)),
+    "`prefix` and `plus = TRUE` both specified; `plus` takes precedence"
+  )
+})


### PR DESCRIPTION
I don't really know what the use is for allowing prefix and suffix to be functions is other than it will allow you to add `+`'s before positive percents. I've added `plus = TRUE` to percent functions `percent()` and `label_percent()` for easy use. Happy to adjust!, and sorry about re-roxing things.