### PR TITLE
Add na.rm support to DiscreteRange$train

### DIFF
--- a/R/range.r
+++ b/R/range.r
@@ -17,8 +17,8 @@ DiscreteRange <- R6::R6Class(
   "DiscreteRange",
   inherit = Range,
   list(
-    train = function(x, drop = FALSE) {
-      self$range <- train_discrete(x, self$range, drop)
+    train = function(x, drop = FALSE, na.rm = FALSE) {
+      self$range <- train_discrete(x, self$range, drop, na.rm)
     },
     reset = function() self$range <- NULL
   )


### PR DESCRIPTION
DiscreteRange train function does not currently support the `na.rm` argument to `train_discrete`,  preventing its direct use to replace ggplot2's range functions (tidyverse/ggplot2#2710). This PR updates the train function to support this argument. 