### PR TITLE
label_bytes() fixes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,7 +38,7 @@
 
 * New `label_bytes()` replaces `number_bytes_format()` with a more 
   convenient interface. It takes a single `unit` argument which can either be
-  an SI unit (e.g. "kB"), a binary unit (e.g. "kIB"), or an automatic unit
+  an SI unit (e.g. "kB"), a binary unit (e.g. "KiB"), or an automatic unit
   (either "auto_si" or "auto_binary").
   
     It always uses "B" as the symbol for bytes (#174), and checks that `units` 
@@ -47,7 +47,7 @@
     
     ```R
     label_bytes("auto_binary")(1024^(1:3))
-    #> [1] "1 kiB" "1 MiB" "1 GiB"
+    #> [1] "1 KiB" "1 MiB" "1 GiB"
     ```
   
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # scales (development version)
 
+* `label_bytes()` now accepts "B" as `units` and always uses "KiB" for kibibytes
+  (#299) and "B" for bytes (@mikmart).
+
 * `manual_pal()` now always returns an unnamed colour vector, which is easy to
   use with `ggplot2::discrete_scale()` (@yutannihilation, #284).
 
@@ -37,7 +40,7 @@
   trying to convert to `"NA"` (@clauswilke, #187).
 
 * New `label_bytes()` replaces `number_bytes_format()` with a more 
-  convenient interface. It takes a single `unit` argument which can either be
+  convenient interface. It takes a single `units` argument which can either be
   an SI unit (e.g. "kB"), a binary unit (e.g. "KiB"), or an automatic unit
   (either "auto_si" or "auto_binary").
   

--- a/R/label-bytes.R
+++ b/R/label-bytes.R
@@ -54,7 +54,10 @@ label_bytes <- function(units = "auto_si", accuracy = 1, ...) {
       power <- findInterval(abs(x), c(0, base^powers)) - 1L
       units <- c("B", units)[power + 1L]
     } else {
-      if (units %in% si_units) {
+      if (units == "B") {
+        base <- 1000
+        power <- 0
+      } else if (units %in% si_units) {
         base <- 1000
         power <- powers[[match(units, si_units)]]
       } else if (units %in% bin_units) {

--- a/R/label-bytes.R
+++ b/R/label-bytes.R
@@ -1,14 +1,14 @@
 #' Label bytes (1 kb, 2 MB, etc)
 #'
 #' Scale bytes into human friendly units. Can use either SI units (e.g.
-#' kB = 1000 bytes) or binary units (e.g. kiB = 1024 bytes). See
+#' kB = 1000 bytes) or binary units (e.g. KiB = 1024 bytes). See
 #' [Units of Information](http://en.wikipedia.org/wiki/Units_of_information)
 #' on Wikipedia for more details.
 #'
 #' @param units Unit to use. Should either one of:
 #'   * "kB", "MB", "GB", "TB", "PB", "EB", "ZB", and "YB" for
 #'     SI units (base 1000).
-#'   * "kiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", and "YiB" for
+#'   * "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", and "YiB" for
 #'     binary units (base 1024).
 #'   * `auto_si` or `auto_binary` to automatically pick the most approrpiate
 #'     unit for each value.
@@ -44,16 +44,16 @@ label_bytes <- function(units = "auto_si", accuracy = 1, ...) {
   function(x) {
     powers <- si_powers[si_powers >= 3] / 3 # powers of 1000
 
+    si_units <- paste0(names(powers), "B")
+    bin_units <- paste0(toupper(names(powers)), "iB")
+
     if (units %in% c("auto_si", "auto_binary")) {
       base <- switch(units, auto_binary = 1024, auto_si = 1000)
-      suffix <- switch(units, auto_binary = "iB", auto_si = "B")
+      units <- switch(units, auto_si = si_units, auto_binary = bin_units)
 
       power <- findInterval(abs(x), c(0, base^powers)) - 1L
-      units <- paste0(c("", names(powers))[power + 1L], suffix)
+      units <- c("B", units)[power + 1L]
     } else {
-      si_units <- paste0(names(powers), "B")
-      bin_units <- paste0(names(powers), "iB")
-
       if (units %in% si_units) {
         base <- 1000
         power <- powers[[match(units, si_units)]]

--- a/man/label_bytes.Rd
+++ b/man/label_bytes.Rd
@@ -11,7 +11,7 @@ label_bytes(units = "auto_si", accuracy = 1, ...)
 \itemize{
 \item "kB", "MB", "GB", "TB", "PB", "EB", "ZB", and "YB" for
 SI units (base 1000).
-\item "kiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", and "YiB" for
+\item "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", and "YiB" for
 binary units (base 1024).
 \item \code{auto_si} or \code{auto_binary} to automatically pick the most approrpiate
 unit for each value.
@@ -32,7 +32,7 @@ returns a character vector of labels.
 }
 \description{
 Scale bytes into human friendly units. Can use either SI units (e.g.
-kB = 1000 bytes) or binary units (e.g. kiB = 1024 bytes). See
+kB = 1000 bytes) or binary units (e.g. KiB = 1024 bytes). See
 \href{http://en.wikipedia.org/wiki/Units_of_information}{Units of Information}
 on Wikipedia for more details.
 }

--- a/tests/testthat/test-label-bytes.R
+++ b/tests/testthat/test-label-bytes.R
@@ -9,9 +9,17 @@ test_that("auto units handles 0 and other special values", {
   expect_equal(label_bytes()(Inf), "Inf")
 })
 
+test_that("auto binary units use B for bytes", {
+  expect_equal(label_bytes("auto_binary")(1), "1 B")
+})
+
 test_that("can use either binary or si units", {
   expect_equal(label_bytes("kB")(1000), "1 kB")
-  expect_equal(label_bytes("kiB")(1024), "1 kiB")
+  expect_equal(label_bytes("KiB")(1024), "1 KiB")
+})
+
+test_that("can use plain bytes as units", {
+  expect_equal(label_bytes("B")(1000), "1 000 B")
 })
 
 test_that("errors if unknown unit", {


### PR DESCRIPTION
Some fixes to `label_bytes()`:

1.  Use "KiB" for kibibytes, rather than "kiB". Fixes #299.
2.  Use "B" for bytes when given `units = "auto_binary"`, rather than "iB".
3.  Allow passing `units = "B"`.
