### PR TITLE
adds `show_col` and `show_pal` to reference index on the website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -59,6 +59,7 @@ reference:
   - contains("col")
   - muted
   - alpha
+  - contains("show_")
 
 - title: Non-colour palette functions
   desc: >


### PR DESCRIPTION
They are currently not indexed here: https://scales.r-lib.org/reference/index.html