### PR TITLE
Adjust auto accuracy heuristic

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,9 @@
   
 * `label_bytes()` now correctly accounts for the `scale` argument when choosing
   auto units (@davidchall, #235).
+  
+* Internal `precision()`, used when `accuracy = NULL`, now avoids displaying
+  unnecessary digits (@davidchall, #304).
 
 # scales 1.1.1
 

--- a/R/label-number.r
+++ b/R/label-number.r
@@ -186,7 +186,15 @@ precision <- function(x) {
   if (smallest_diff < sqrt(.Machine$double.eps)) {
     1
   } else {
+    precision <- 10^(floor(log10(smallest_diff)) - 1)
+
+    # reduce precision when 2nd sig fig always 0
+    reduce_precision <- all(round(x / precision) %% 10 == 0)
+    if (reduce_precision) {
+      precision <- precision * 10
+    }
+
     # Never return precision bigger than 1
-    pmin(10^(floor(log10(smallest_diff)) - 1), 1)
+    pmin(precision, 1)
   }
 }

--- a/R/label-number.r
+++ b/R/label-number.r
@@ -189,8 +189,7 @@ precision <- function(x) {
     precision <- 10^(floor(log10(smallest_diff)) - 1)
 
     # reduce precision when final digit always 0
-    reduce_precision <- all(round(x / precision) %% 10 == 0)
-    if (reduce_precision) {
+    if (all(round(x / precision) %% 10 == 0)) {
       precision <- precision * 10
     }
 

--- a/R/label-number.r
+++ b/R/label-number.r
@@ -188,7 +188,7 @@ precision <- function(x) {
   } else {
     precision <- 10^(floor(log10(smallest_diff)) - 1)
 
-    # reduce precision when 2nd sig fig always 0
+    # reduce precision when final digit always 0
     reduce_precision <- all(round(x / precision) %% 10 == 0)
     if (reduce_precision) {
       precision <- precision * 10

--- a/tests/testthat/test-label-dollar.R
+++ b/tests/testthat/test-label-dollar.R
@@ -40,7 +40,7 @@ test_that("rescale_large compatible with scale argument", {
 
   expect_equal(
     label_dollar(scale = 2, rescale_large = rescale_short_scale())(x * 1e3),
-    c("$2.0K", "$4.0K", "$20.0K", "$200.0K")
+    c("$2K", "$4K", "$20K", "$200K")
   )
   expect_equal(
     label_dollar(scale = 2, rescale_large = rescale_short_scale())(x * 1e4),

--- a/tests/testthat/test-label-number-si.R
+++ b/tests/testthat/test-label-number-si.R
@@ -4,7 +4,7 @@ test_that("rescales values independently", {
     number_si(10^c(-24, -21, -18, -15, -12, -9, -6, -3, 0, 3, 6, 9, 12, 15, 18, 21, 24)),
     c("1y", "1z", "1a", "1f", "1p", "1n", "1\u00b5", "1m", "1", "1k", "1M", "1G", "1T", "1P", "1E", "1Z", "1Y")
   )
-  expect_equal(number_si(c(-1e3, 1e6, 1e9)), c("-1.0k", "1.0M", "1.0G"))
+  expect_equal(number_si(c(-1e3, 1e6, 1e9)), c("-1k", "1M", "1G"))
 })
 
 test_that("requires unit argument", {

--- a/tests/testthat/test-label-number.r
+++ b/tests/testthat/test-label-number.r
@@ -87,9 +87,18 @@ test_that("precision rounds large numbers appropriately", {
   expect_equal(precision(x * 10000), 1)
 })
 
+test_that("precision is reduced when possible", {
+  expect_equal(precision(c(0, 0.01)), 0.01)
+  expect_equal(precision(c(0, 0.011)), 0.001)
+  expect_equal(precision(c(0, 0.0101)), 0.01)
+  expect_equal(precision(c(0, 0.0109)), 0.001)
+
+  expect_equal(precision(c(0.251, 0.351)), 0.01)
+})
+
 test_that("precision handles duplicate values", {
   expect_equal(precision(c(0, 0, 0.025)), 0.001)
-  expect_equal(precision(c(Inf, 0.1, 0.2, Inf)), 0.01)
+  expect_equal(precision(c(Inf, 0.1, 0.2, Inf)), 0.1)
 })
 
 test_that("precision ignores Inf and NA", {

--- a/tests/testthat/test-label-percent.R
+++ b/tests/testthat/test-label-percent.R
@@ -18,8 +18,8 @@ test_that("preserves names", {
 
 test_that("default accuracy works for range of inputs", {
   x <- c(0.1, 0.2, 0.5)
-  expect_equal(percent(x / 100), c("0.10%", "0.20%", "0.50%"))
-  expect_equal(percent(x / 10), c("1.0%", "2.0%", "5.0%"))
+  expect_equal(percent(x / 100), c("0.1%", "0.2%", "0.5%"))
+  expect_equal(percent(x / 10), c("1%", "2%", "5%"))
   expect_equal(percent(x), c("10%", "20%", "50%"))
   expect_equal(percent(x * 10), c("100%", "200%", "500%"))
 })

--- a/tests/testthat/test-labels-retired.R
+++ b/tests/testthat/test-labels-retired.R
@@ -1,7 +1,7 @@
 test_that("unit format", {
   expect_equal(
     unit_format(unit = "km", scale = 1e-3)(c(1e3, NA, 2e3)),
-    c("1.0 km", NA, "2.0 km")
+    c("1 km", NA, "2 km")
   )
   expect_equal(
     unit_format(unit = "ha", scale = 1e-4, accuracy = .1)(c(1e3, 2e3)),


### PR DESCRIPTION
Fixes #279

The auto accuracy heuristic shows 2 significant figures, relative to the smallest difference between breaks. This is designed to handle situations like (taken from [tidyverse blog post](https://www.tidyverse.org/blog/2019/11/scales-1-1-0/)):

![](https://www.tidyverse.org/blog/2019/11/scales-1-1-0/figs/unnamed-chunk-4-1.png)

However, this heuristic displays an unnecessary digit in the specific case when all the breaks align with zeros in the final digit. This situation naturally occurs very often. Here's an example (taken from the [scales docs](https://scales.r-lib.org/reference/label_number_si.html)):

<img width="695" alt="image" src="https://user-images.githubusercontent.com/1804856/112726992-6fd3cc00-8edd-11eb-99d8-45a8a8836dcb.png">

This PR reduces the precision when final digit is always zero.

## Before

``` r
library(scales)

number(seq(0, 0.1, 0.025))
#> [1] "0.000" "0.025" "0.050" "0.075" "0.100"
number(seq(0, 20, 5))
#> [1] "0.0"  "5.0"  "10.0" "15.0" "20.0"
```

<sup>Created on 2021-03-27 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>

## After

``` r
library(scales)

number(seq(0, 0.1, 0.025))
#> [1] "0.000" "0.025" "0.050" "0.075" "0.100"
number(seq(0, 20, 5))
#> [1] "0"  "5"  "10" "15" "20"
```

<sup>Created on 2021-03-27 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>
