### PR TITLE
Fix `label_number_auto()` to work on single values > 1e+06 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # scales (development version)
 
+* `label_number_auto()` correctly formats single numbers that are greater than
+  1e+06 without an error (@karawoo, #321)
+
 * `manual_pal()` now always returns an unnamed colour vector, which is easy to
   use with `ggplot2::discrete_scale()` (@yutannihilation, #284).
 

--- a/R/label-number-auto.R
+++ b/R/label-number-auto.R
@@ -53,7 +53,7 @@ label_number_auto <- function() {
 format_shortest <- function(breaks, ...) {
   options <- list(...)
   labels <- vapply(options, function(labeller) labeller(breaks), character(length(breaks)))
-  apply(labels, 1, shortest)
+  apply(matrix(labels, nrow = length(breaks)), 1, shortest)
 }
 
 shortest <- function(x) {

--- a/tests/testthat/test-label-number-auto.R
+++ b/tests/testthat/test-label-number-auto.R
@@ -28,3 +28,7 @@ test_that("tricky breaks don't change unexpectedly", {
     number_auto(10^(1:7))
   })
 })
+
+test_that("single values > 1e+06 don't throw error", {
+  expect_equal(label_number_auto()(30925005), "30 925 005")
+})


### PR DESCRIPTION
Fixes #321. `vapply()` would return a character vector instead of a matrix when formatting a single value, which then caused `apply()` to throw an error. This ensures that we're calling `apply()` on a matrix with the necessary dimensions.
