### PR TITLE
Derivatives of transformations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,8 @@
 * Add an inverse (area) hyperbolic sine transformation `asinh_trans()`, which
   provides a logarithm-like transformation of a space, but which accommodates
   negative values (#297)
+* Transformation objects can optionally include the derivatives of the transform
+  and the inverse transform (@mjskay, #322).
 
 # scales 1.2.1
 

--- a/R/trans-numeric.R
+++ b/R/trans-numeric.R
@@ -243,8 +243,8 @@ identity_trans <- function() {
     "identity",
     "force",
     "force",
-    d_transform = function(x) 1,
-    d_inverse = function(x) 1
+    d_transform = function(x) rep(1, length(x)),
+    d_inverse = function(x) rep(1, length(x))
   )
 }
 
@@ -383,8 +383,8 @@ reverse_trans <- function() {
     "reverse",
     function(x) -x,
     function(x) -x,
-    d_transform = function(x) -1,
-    d_inverse = function(x) -1,
+    d_transform = function(x) rep(-1, length(x)),
+    d_inverse = function(x) rep(-1, length(x)),
     minor_breaks = regular_minor_breaks(reverse = TRUE)
   )
 }

--- a/R/trans-numeric.R
+++ b/R/trans-numeric.R
@@ -42,7 +42,9 @@ asinh_trans <- function() {
   trans_new(
     "asinh",
     transform = asinh,
-    inverse = sinh
+    inverse = sinh,
+    d_transform = function(x) 1 / sqrt(x^2 + 1),
+    d_inverse = cosh
   )
 }
 

--- a/R/trans.R
+++ b/R/trans.R
@@ -3,14 +3,19 @@
 #' A transformation encapsulates a transformation and its inverse, as well
 #' as the information needed to create pleasing breaks and labels. The `breaks()`
 #' function is applied on the un-transformed range of the data, and the
-#' `format()` function takes the output of the `breaks()` function and return
-#' well-formatted labels.
+#' `format()` function takes the output of the `breaks()` function and returns
+#' well-formatted labels. Transformations may also include the derivatives of the
+#' transformation and its inverse, but are not required to.
 #'
 #' @param name transformation name
 #' @param transform function, or name of function, that performs the
 #'   transformation
 #' @param inverse function, or name of function, that performs the
 #'   inverse of the transformation
+#' @param d_transform Optional function, or name of function, that gives the
+#'   derivative of the transformation. May be `NULL`.
+#' @param d_inverse Optional function, or name of function, that gives the
+#'   derivative of the inverse of the transformation. May be `NULL`.
 #' @param breaks default breaks function for this transformation. The breaks
 #'   function is applied to the un-transformed data.
 #' @param minor_breaks default minor breaks function for this transformation.
@@ -23,17 +28,23 @@
 #' @export
 #' @keywords internal
 #' @aliases trans
-trans_new <- function(name, transform, inverse, breaks = extended_breaks(),
+trans_new <- function(name, transform, inverse,
+                      d_transform = NULL, d_inverse = NULL,
+                      breaks = extended_breaks(),
                       minor_breaks = regular_minor_breaks(),
                       format = format_format(), domain = c(-Inf, Inf)) {
   if (is.character(transform)) transform <- match.fun(transform)
   if (is.character(inverse)) inverse <- match.fun(inverse)
+  if (is.character(d_transform)) d_transform <- match.fun(d_transform)
+  if (is.character(d_inverse)) d_inverse <- match.fun(d_inverse)
 
   structure(
     list(
       name = name,
       transform = transform,
       inverse = inverse,
+      d_transform = d_transform,
+      d_inverse = d_inverse,
       breaks = breaks,
       minor_breaks = minor_breaks,
       format = format,

--- a/man/probability_trans.Rd
+++ b/man/probability_trans.Rd
@@ -14,8 +14,9 @@ probit_trans()
 }
 \arguments{
 \item{distribution}{probability distribution.  Should be standard R
-abbreviation so that "p" + distribution is a valid probability density
-function, and "q" + distribution is a valid quantile function.}
+abbreviation so that "p" + distribution is a valid cumulative distribution
+function, "q" + distribution is a valid quantile function, and
+"d" + distribution is a valid probability density function.}
 
 \item{...}{other arguments passed on to distribution and quantile functions}
 }

--- a/man/trans_new.Rd
+++ b/man/trans_new.Rd
@@ -11,6 +11,8 @@ trans_new(
   name,
   transform,
   inverse,
+  d_transform = NULL,
+  d_inverse = NULL,
   breaks = extended_breaks(),
   minor_breaks = regular_minor_breaks(),
   format = format_format(),
@@ -30,6 +32,12 @@ transformation}
 \item{inverse}{function, or name of function, that performs the
 inverse of the transformation}
 
+\item{d_transform}{Optional function, or name of function, that gives the
+derivative of the transformation. May be \code{NULL}.}
+
+\item{d_inverse}{Optional function, or name of function, that gives the
+derivative of the inverse of the transformation. May be \code{NULL}.}
+
 \item{breaks}{default breaks function for this transformation. The breaks
 function is applied to the un-transformed data.}
 
@@ -46,8 +54,9 @@ argument.}
 A transformation encapsulates a transformation and its inverse, as well
 as the information needed to create pleasing breaks and labels. The \code{breaks()}
 function is applied on the un-transformed range of the data, and the
-\code{format()} function takes the output of the \code{breaks()} function and return
-well-formatted labels.
+\code{format()} function takes the output of the \code{breaks()} function and returns
+well-formatted labels. Transformations may also include the derivatives of the
+transformation and its inverse, but are not required to.
 }
 \seealso{
 \Sexpr[results=rd,stage=build]{scales:::seealso_trans()}

--- a/tests/testthat/test-trans-compose.R
+++ b/tests/testthat/test-trans-compose.R
@@ -4,6 +4,18 @@ test_that("composes transforms correctly", {
   expect_equal(t$inverse(-2), 100)
 })
 
+test_that("composes derivatives correctly", {
+  t <- compose_trans("sqrt", "reciprocal", "reverse")
+  expect_equal(t$d_transform(0.25), 4)
+  expect_equal(t$d_inverse(-2), 0.25)
+})
+
+test_that("produces NULL derivatives if not all transforms have derivatives", {
+  t <- compose_trans("sqrt", trans_new("no_deriv", identity, identity))
+  expect_null(t$d_transform)
+  expect_null(t$d_inverse)
+})
+
 test_that("uses breaks from first transformer", {
   t <- compose_trans("log10", "reverse")
   expect_equal(t$breaks(c(1, 1000)), log_breaks()(c(1, 1000)))

--- a/tests/testthat/test-trans-numeric.R
+++ b/tests/testthat/test-trans-numeric.R
@@ -142,6 +142,15 @@ test_that("atanh_trans derivatives work", {
   expect_equal(trans$d_inverse(x), 1 / trans$d_transform(trans$inverse(x)))
 })
 
+test_that("asinh_trans derivatives work", {
+  trans <- asinh_trans()
+  expect_equal(trans$d_transform(c(-1, 0, 1)), c(sqrt(2) / 2, 1, sqrt(2) / 2))
+  expect_equal(trans$d_inverse(c(-log(2), 0, log(2))), c(1.25, 1, 1.25))
+  x <- seq(-0.9, 0.9, length.out = 10)
+  expect_equal(trans$d_transform(x), 1 / trans$d_inverse(trans$transform(x)))
+  expect_equal(trans$d_inverse(x), 1 / trans$d_transform(trans$inverse(x)))
+})
+
 test_that("boxcox_trans derivatives work", {
   trans <- boxcox_trans(p = 0, offset = 1)
   expect_equal(trans$d_transform(c(0, 1, 2)), c(1, 1/2, 1/3))

--- a/tests/testthat/test-trans-numeric.R
+++ b/tests/testthat/test-trans-numeric.R
@@ -121,3 +121,147 @@ test_that("probability transforms have domain (0,1)", {
   expect_equal(logit_trans()$domain, c(0, 1))
   expect_equal(probit_trans()$domain, c(0, 1))
 })
+
+# Derivatives -------------------------------------------------------------
+
+test_that("asn_trans derivatives work", {
+  trans <- asn_trans()
+  expect_equal(trans$d_transform(c(0, 0.5, 1)), c(Inf, 2, Inf))
+  expect_equal(trans$d_inverse(c(0, pi/2, pi)), c(0, 0.5, 0))
+  x <- seq(0.1, 0.9, length.out = 10)
+  expect_equal(trans$d_transform(x), 1 / trans$d_inverse(trans$transform(x)))
+  expect_equal(trans$d_inverse(x), 1 / trans$d_transform(trans$inverse(x)))
+})
+
+test_that("atanh_trans derivatives work", {
+  trans <- atanh_trans()
+  expect_equal(trans$d_transform(c(-1, 0, 1)), c(Inf, 1, Inf))
+  expect_equal(trans$d_inverse(c(-log(2), 0, log(2))), c(0.64, 1, 0.64))
+  x <- seq(-0.9, 0.9, length.out = 10)
+  expect_equal(trans$d_transform(x), 1 / trans$d_inverse(trans$transform(x)))
+  expect_equal(trans$d_inverse(x), 1 / trans$d_transform(trans$inverse(x)))
+})
+
+test_that("boxcox_trans derivatives work", {
+  trans <- boxcox_trans(p = 0, offset = 1)
+  expect_equal(trans$d_transform(c(0, 1, 2)), c(1, 1/2, 1/3))
+  expect_equal(trans$d_inverse(c(0, 1, 2)), exp(c(0, 1, 2)))
+  x <- 0:10
+  expect_equal(trans$d_transform(x), 1 / trans$d_inverse(trans$transform(x)))
+  expect_equal(trans$d_inverse(x), 1 / trans$d_transform(trans$inverse(x)))
+
+  trans <- boxcox_trans(p = 2, offset = 2)
+  expect_equal(trans$d_transform(c(0, 1, 2)), c(2, 3, 4))
+  expect_equal(trans$d_inverse(c(0, 0.5, 4)), c(1, sqrt(2) / 2, 1/3))
+  expect_equal(trans$d_transform(x), 1 / trans$d_inverse(trans$transform(x)))
+  expect_equal(trans$d_inverse(x), 1 / trans$d_transform(trans$inverse(x)))
+})
+
+test_that("modulus_trans derivatives work", {
+  trans <- modulus_trans(p = 0, offset = 1)
+  expect_equal(trans$d_transform(c(-2, -1, 1, 2)), c(1/3, 1/2, 1/2, 1/3))
+  expect_equal(trans$d_inverse(c(-2, -1, 1, 2)), exp(c(2, 1, 1, 2)))
+  x <- c(-10:-2, 2:10)
+  expect_equal(trans$d_transform(x), 1 / trans$d_inverse(trans$transform(x)))
+  expect_equal(trans$d_inverse(x), 1 / trans$d_transform(trans$inverse(x)))
+
+  trans <- modulus_trans(p = 2, offset = 2)
+  expect_equal(trans$d_transform(c(-2, -1, 1, 2)), c(4, 3, 3, 4))
+  expect_equal(trans$d_inverse(c(-4, -0.5, 0.5, 4)), c(1/3, sqrt(2) / 2, sqrt(2) / 2, 1/3))
+  expect_equal(trans$d_transform(x), 1 / trans$d_inverse(trans$transform(x)))
+  expect_equal(trans$d_inverse(x), 1 / trans$d_transform(trans$inverse(x)))
+})
+
+test_that("yj_trans derivatives work", {
+  trans <- yj_trans(p = 0)
+  expect_equal(trans$d_transform(c(-2, -1, 1, 2)), c(3, 2, 0.5, 1/3))
+  expect_equal(trans$d_inverse(c(-1/2, 1, 2)), c(sqrt(2) / 2, exp(1), exp(2)))
+  x <- c(-10:10)
+  expect_equal(trans$d_transform(x), 1 / trans$d_inverse(trans$transform(x)))
+  expect_equal(trans$d_inverse(x), 1 / trans$d_transform(trans$inverse(x)))
+
+  trans <- yj_trans(p = 3)
+  expect_equal(trans$d_transform(c(-2, -1, 1, 2)), c(1/9, 1/4, 4, 9))
+  expect_equal(trans$d_inverse(c(-4, -0.5, 1)), c(1/9, 4, (1/16)^(1/3)))
+  expect_equal(trans$d_transform(x), 1 / trans$d_inverse(trans$transform(x)))
+  expect_equal(trans$d_inverse(0:10), 1 / trans$d_transform(trans$inverse(0:10)))
+})
+
+test_that("exp_trans derivatives work", {
+  trans <- exp_trans(10)
+  expect_equal(trans$d_transform(c(0, 1, 2)), c(1, 10, 100) * log(10))
+  expect_equal(trans$d_inverse(c(0.1, 1, 10) / log(10)), c(10, 1, 0.1))
+  x <- 1:10
+  expect_equal(trans$d_transform(x), 1 / trans$d_inverse(trans$transform(x)))
+  expect_equal(trans$d_inverse(x), 1 / trans$d_transform(trans$inverse(x)))
+})
+
+test_that("identity_trans derivatives work", {
+  trans <- identity_trans()
+  expect_equal(trans$d_transform(numeric(0)), numeric(0))
+  expect_equal(trans$d_transform(c(0, 1, 2)), c(1, 1, 1))
+  expect_equal(trans$d_inverse(numeric(0)), numeric(0))
+  expect_equal(trans$d_inverse(c(0, 1, 2)), c(1, 1, 1))
+})
+
+test_that("log_trans derivatives work", {
+  trans <- log_trans(10)
+  expect_equal(trans$d_transform(c(0.1, 1, 10) / log(10)), c(10, 1, 0.1))
+  expect_equal(trans$d_inverse(c(0, 1, 2)), c(1, 10, 100) * log(10))
+  x <- 1:10
+  expect_equal(trans$d_transform(x), 1 / trans$d_inverse(trans$transform(x)))
+  expect_equal(trans$d_inverse(x), 1 / trans$d_transform(trans$inverse(x)))
+})
+
+test_that("log1p_trans derivatives work", {
+  trans <- log1p_trans()
+  expect_equal(trans$d_transform(c(0, 1, 2)), c(1, 1/2, 1/3))
+  expect_equal(trans$d_inverse(c(0, 1, 2)), exp(c(0, 1, 2)))
+  x <- 0:10
+  expect_equal(trans$d_transform(x), 1 / trans$d_inverse(trans$transform(x)))
+  expect_equal(trans$d_inverse(x), 1 / trans$d_transform(trans$inverse(x)))
+})
+
+test_that("pseudo_log_trans derivatives work", {
+  trans <- pseudo_log_trans(0.5)
+  expect_equal(trans$d_transform(c(0, 1)), c(1, sqrt(2) / 2))
+  expect_equal(trans$d_inverse(c(0, 1)), c(1, cosh(1)))
+  x <- 1:10
+  expect_equal(trans$d_transform(x), 1 / trans$d_inverse(trans$transform(x)))
+  expect_equal(trans$d_inverse(x), 1 / trans$d_transform(trans$inverse(x)))
+})
+
+test_that("logit_trans derivatives work", {
+  trans <- logit_trans()
+  expect_equal(trans$d_transform(c(0.1, 0.5, 0.8)), c(100/9, 4, 6.25))
+  expect_equal(trans$d_inverse(c(0, 1, 2)), dlogis(c(0, 1, 2)))
+  x <- seq(0.1, 0.9, length.out = 10)
+  expect_equal(trans$d_transform(x), 1 / trans$d_inverse(trans$transform(x)))
+  expect_equal(trans$d_inverse(x), 1 / trans$d_transform(trans$inverse(x)))
+})
+
+test_that("reciprocal_trans derivatives work", {
+  trans <- reciprocal_trans()
+  expect_equal(trans$d_transform(c(0.1, 1, 10)), c(-100, -1, -0.01))
+  expect_equal(trans$d_inverse(c(0.1, 1, 10)), c(-100, -1, -0.01))
+  x <- (1:20)/10
+  expect_equal(trans$d_transform(x), 1 / trans$d_inverse(trans$transform(x)))
+  expect_equal(trans$d_inverse(x), 1 / trans$d_transform(trans$inverse(x)))
+})
+
+test_that("reverse_trans derivatives work", {
+  trans <- reverse_trans()
+  expect_equal(trans$d_transform(numeric(0)), numeric(0))
+  expect_equal(trans$d_transform(c(-1, 1, 2)), c(-1, -1, -1))
+  expect_equal(trans$d_inverse(numeric(0)), numeric(0))
+  expect_equal(trans$d_inverse(c(-1, 1, 2)), c(-1, -1, -1))
+})
+
+test_that("sqrt_trans derivatives work", {
+  trans <- sqrt_trans()
+  expect_equal(trans$d_transform(c(1, 4, 9)), c(1/2, 1/4, 1/6))
+  expect_equal(trans$d_inverse(c(1, 2, 3)), c(2, 4, 6))
+  x <- 1:10
+  expect_equal(trans$d_transform(x), 1 / trans$d_inverse(trans$transform(x)))
+  expect_equal(trans$d_inverse(x), 1 / trans$d_transform(trans$inverse(x)))
+})


### PR DESCRIPTION
This PR closes #322 by supplying derivatives of transformation functions and inverses where possible.

Specifically, it:

- Adds two optional, may-be-`NULL` fields to transform objects: `$d_transform` and `$d_inverse`. These functions are the derivatives of `$transform` and `$inverse`.
- Supplies derivatives for all existing numeric transformations
- Applies the chain rule to give derivatives for `compose_trans()` (unless any derivatives in the transformation are missing, in which case the corresponding derivative function is `NULL`).
- Includes tests for all of the above.

Some possible discussion points:

- I initially used `$transform_deriv` and `$inverse_deriv`, but found that existing tests used partial matching on `$trans` and `$inv`, so these names caused failures. I wasn't sure if other legacy code relies on this partial matching, so I conservatively went with the names `$d_transform` and `$d_inverse`. I am not sure these are the best names and am happy to change them.
- I did not supply derivatives for the date transform. Arguably those derivatives could be a constant like `identity_trans()`, at least for applications like I am imagining these will be used for (plotting densities), but I went with the more conservative choice of not including it.
