### PR TITLE
Fix typos

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -40,7 +40,7 @@ devtools::install_github("r-lib/scales")
 
 ### Breaks and labels
 
-The most common use of the scales package is to customise to control the appearance of axis and legend labels. Use a `break_` function to control how breaks are generated from the limits, and a `label_` function to control how breaks are turned in to labels.
+The most common use of the scales package is to control the appearance of axis and legend labels. Use a `break_` function to control how breaks are generated from the limits, and a `label_` function to control how breaks are turned in to labels.
 
 ```{r labels}
 library(ggplot2)
@@ -77,7 +77,7 @@ economics %>%
   )
 ```
 
-Generally, I don't recommend running `library(scales)` because when you type (e.g.) `scales::label_` autocomplete will provide you with a list of labelling functions to job your memory.
+Generally, I don't recommend running `library(scales)` because when you type (e.g.) `scales::label_` autocomplete will provide you with a list of labelling functions to jog your memory.
 
 ### Advanced features
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ devtools::install_github("r-lib/scales")
 
 ### Breaks and labels
 
-The most common use of the scales package is to customise to control the
-appearance of axis and legend labels. Use a `break_` function to control
-how breaks are generated from the limits, and a `label_` function to
-control how breaks are turned in to labels.
+The most common use of the scales package is to control the appearance
+of axis and legend labels. Use a `break_` function to control how breaks
+are generated from the limits, and a `label_` function to control how
+breaks are turned in to labels.
 
 ``` r
 library(ggplot2)
@@ -85,7 +85,7 @@ economics %>%
 
 Generally, I don’t recommend running `library(scales)` because when you
 type (e.g.) `scales::label_` autocomplete will provide you with a list
-of labelling functions to job your memory.
+of labelling functions to jog your memory.
 
 ### Advanced features
 


### PR DESCRIPTION
This PR fixes 2 typos in the README. Testing fails (locally at least) due to #347.