### PR TITLE
Fix #352 to make label_date_short() render all labels of the same level inline

### DIFF
--- a/R/label-date.R
+++ b/R/label-date.R
@@ -81,9 +81,9 @@ label_date_short <- function(format = c("%Y", "%b", "%d", "%H:%M"), sep = "\n") 
     }
 
     for_mat <- cbind(
-      ifelse(changes[, 1], format[[1]], NA),
-      ifelse(changes[, 2], format[[2]], NA),
-      ifelse(changes[, 3], format[[3]], NA),
+      ifelse(changes[, 1], format[[1]], ""),
+      ifelse(changes[, 2], format[[2]], ""),
+      ifelse(changes[, 3], format[[3]], ""),
       format[[4]]
     )
 


### PR DESCRIPTION
Before with `theme(axis_text = element_text(vjust = 0.5)`:
<img width="427" alt="image" src="https://user-images.githubusercontent.com/55065152/173015496-7ce3760a-f109-4f84-a614-75232160acc4.png">

After with `theme(axis_text = element_text(vjust = 0.5)`:
<img width="431" alt="image" src="https://user-images.githubusercontent.com/55065152/173015760-2752a75a-b7a5-4f74-a15d-c43051f8a457.png">

Haven't done a pull request to another library before, so apologies if I've done something incorrect 