### PR TITLE
set default domain for `probability_trans`

### DIFF
--- a/R/trans-numeric.r
+++ b/R/trans-numeric.r
@@ -269,14 +269,15 @@ pseudo_log_trans <- function(sigma = 1, base = exp(1)) {
 #' @examples
 #' plot(logit_trans(), xlim = c(0, 1))
 #' plot(probit_trans(), xlim = c(0, 1))
-probability_trans <- function(distribution, ...) {
+probability_trans <- function(distribution, ..., domain = c(0,1)) {
   qfun <- match.fun(paste0("q", distribution))
   pfun <- match.fun(paste0("p", distribution))
 
   trans_new(
     paste0("prob-", distribution),
     function(x) qfun(x, ...),
-    function(x) pfun(x, ...)
+    function(x) pfun(x, ...),
+    domain = domain
   )
 }
 #' @export

--- a/R/trans-numeric.r
+++ b/R/trans-numeric.r
@@ -265,6 +265,7 @@ pseudo_log_trans <- function(sigma = 1, base = exp(1)) {
 #'   abbreviation so that "p" + distribution is a valid probability density
 #'   function, and "q" + distribution is a valid quantile function.
 #' @param ... other arguments passed on to distribution and quantile functions
+#' @inheritParams trans_new
 #' @export
 #' @examples
 #' plot(logit_trans(), xlim = c(0, 1))

--- a/man/probability_trans.Rd
+++ b/man/probability_trans.Rd
@@ -6,7 +6,7 @@
 \alias{probit_trans}
 \title{Probability transformation}
 \usage{
-probability_trans(distribution, ...)
+probability_trans(distribution, ..., domain = c(0, 1))
 
 logit_trans()
 
@@ -18,6 +18,9 @@ abbreviation so that "p" + distribution is a valid probability density
 function, and "q" + distribution is a valid quantile function.}
 
 \item{...}{other arguments passed on to distribution and quantile functions}
+
+\item{domain}{domain, as numeric vector of length 2, over which
+transformation is valued}
 }
 \description{
 Probability transformation

--- a/tests/testthat/test-trans-numeric.r
+++ b/tests/testthat/test-trans-numeric.r
@@ -116,3 +116,8 @@ test_that("Yeo-Johnson transform works", {
   expect_equal(yj_trans(lambdas[2])$transform(x[[2]]), expected_data[[2]])
   expect_equal(yj_trans(lambdas[3])$transform(x[[3]]), expected_data[[3]])
 })
+
+test_that("probability transforms have domain (0,1)", {
+  expect_true(all(logit_trans()$domain == c(0, 1)))
+  expect_true(all(probit_trans()$domain == c(0, 1)))
+})


### PR DESCRIPTION
The domain of a q... distribution function is a probability, aka (0,1)

Alternatively, sensible to exclude domain from the arguments, and simply set it in `trans_new` without allowing user intervention.