### PR TITLE
update label_percent ... documentation

### DIFF
--- a/R/label-percent.R
+++ b/R/label-percent.R
@@ -1,5 +1,6 @@
 #' Label percentages (2.5%, 50%, etc)
 #'
+#' @param ... Other arguments passed on to [label_number()]
 #' @inherit label_number return params
 #' @export
 #' @family labels for continuous scales
@@ -16,7 +17,7 @@
 label_percent <- function(accuracy = NULL, scale = 100, prefix = "",
                           suffix = "%", big.mark = " ", decimal.mark = ".",
                           trim = TRUE, ...) {
-  number_format(
+  label_number(
     accuracy = accuracy,
     scale = scale,
     prefix = prefix,

--- a/R/label-percent.R
+++ b/R/label-percent.R
@@ -1,6 +1,6 @@
 #' Label percentages (2.5%, 50%, etc)
 #'
-#' @param ... Other arguments passed on to [label_number()]
+#' @inheritDotParams label_number
 #' @inherit label_number return params
 #' @export
 #' @family labels for continuous scales
@@ -39,7 +39,7 @@ label_percent <- function(accuracy = NULL, scale = 100, prefix = "",
 #'
 #' @keywords internal
 #' @export
-#' @inheritParams label_percent
+#' @inheritParams label_number
 percent_format <- label_percent
 
 #' @export

--- a/man/label_percent.Rd
+++ b/man/label_percent.Rd
@@ -41,7 +41,35 @@ decimal point.}
 \item{trim}{Logical, if \code{FALSE}, values are right-justified to a common
 width (see \code{\link[base:format]{base::format()}}).}
 
-\item{...}{Other arguments passed on to \code{\link[=label_number]{label_number()}}}
+\item{...}{
+  Arguments passed on to \code{\link[=label_number]{label_number}}
+  \describe{
+    \item{\code{style_positive}}{A string that determines the style of positive numbers:
+\itemize{
+\item \code{"none"} (the default): no change, e.g. \code{1}.
+\item \code{"plus"}: preceded by \code{+}, e.g. \code{+1}.
+}}
+    \item{\code{style_negative}}{A string that determines the style of negative numbers:
+\itemize{
+\item \code{"hyphen"} (the default): preceded by a standard hypen \code{-}, e.g. \code{-1}.
+\item \code{"minus"}, uses a proper Unicode minus symbol. This is a typographical
+nicety that ensures \code{-} aligns with the horizontal bar of the
+the horizontal bar of \code{+}.
+\item \code{"parens"}, wrapped in parentheses, e.g. \code{(1)}.
+}}
+    \item{\code{scale_cut}}{Named numeric vector that allows you to rescale large
+(or small) numbers and add a prefix. Built-in helpers include:
+\itemize{
+\item \code{cut_short_scale()}: [10^3, 10^6) = K, [10^6, 10^9) = M, [10^9, 10^12) = B, [10^12, Inf) = T.
+\item \code{cut_long_scale()}: [10^3, 10^6) = K, [10^6, 10^12) = M, [10^12, 10^18) = B, [10^18, Inf) = T.
+\item \code{cut_si(unit)}: uses standard SI units.
+}
+
+If you supply a vector \code{c(a = 100, b = 1000)}, absolute values in the
+range \verb{[0, 100)} will not be rescaled, absolute values in the range \verb{[100, 1000)}
+will be divided by 100 and given the suffix "a", and absolute values in
+the range \verb{[1000, Inf)} will be divided by 1000 and given the suffix "b".}
+  }}
 }
 \value{
 All \code{label_()} functions return a "labelling" function, i.e. a function that

--- a/man/label_percent.Rd
+++ b/man/label_percent.Rd
@@ -41,7 +41,7 @@ decimal point.}
 \item{trim}{Logical, if \code{FALSE}, values are right-justified to a common
 width (see \code{\link[base:format]{base::format()}}).}
 
-\item{...}{Other arguments passed on to \code{\link[base:format]{base::format()}}.}
+\item{...}{Other arguments passed on to \code{\link[=label_number]{label_number()}}}
 }
 \value{
 All \code{label_()} functions return a "labelling" function, i.e. a function that

--- a/man/percent_format.Rd
+++ b/man/percent_format.Rd
@@ -54,7 +54,17 @@ decimal point.}
 \item{trim}{Logical, if \code{FALSE}, values are right-justified to a common
 width (see \code{\link[base:format]{base::format()}}).}
 
-\item{...}{Other arguments passed on to \code{\link[=label_number]{label_number()}}}
+\item{...}{Other arguments passed on to \code{\link[base:format]{base::format()}}.}
+}
+\value{
+All \code{label_()} functions return a "labelling" function, i.e. a function that
+takes a vector \code{x} and returns a character vector of \code{length(x)} giving a
+label for each input value.
+
+Labelling functions are designed to be used with the \code{labels} argument of
+ggplot2 scales. The examples demonstrate their use with x scales, but
+they work similarly for all scales, including those that generate legends
+rather than axes.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}

--- a/man/percent_format.Rd
+++ b/man/percent_format.Rd
@@ -54,7 +54,7 @@ decimal point.}
 \item{trim}{Logical, if \code{FALSE}, values are right-justified to a common
 width (see \code{\link[base:format]{base::format()}}).}
 
-\item{...}{Other arguments passed on to \code{\link[base:format]{base::format()}}.}
+\item{...}{Other arguments passed on to \code{\link[=label_number]{label_number()}}}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}


### PR DESCRIPTION
addresses #356: reflects pass through `label_number` first (i.e. can also include style_+/-)

also update internals of label_percent to skip superceded function.