### PR TITLE
scales::alpha() performance and color format ("character" or "native")

### DIFF
--- a/R/colour-manip.r
+++ b/R/colour-manip.r
@@ -44,29 +44,46 @@ muted <- function(colour, l = 30, c = 70) col2hcl(colour, l = l, c = c)
 #' @param colour colour
 #' @param alpha new alpha level in \[0,1].  If alpha is `NA`,
 #'   existing alpha values are preserved.
+#' @param color_fmt A string, whether the output should be a character vector
+#'   with colours (`"character"`) or an integer vector in the native color
+#'   format (`"native"`)
 #' @export
 #' @examples
 #' alpha("red", 0.1)
 #' alpha(colours(), 0.5)
 #' alpha("red", seq(0, 1, length.out = 10))
 #' alpha(c("first" = "gold", "second" = "lightgray", "third" = "#cd7f32"), .5)
-alpha <- function(colour, alpha = NA) {
+alpha <- function(colour, alpha = NA, color_fmt = "character") {
+  color_fmt <- match.arg(color_fmt, c("character", "native"))
   if (length(colour) != length(alpha)) {
     if (length(colour) > 1 && length(alpha) > 1) {
       stop("Only one of colour and alpha can be vectorised")
     }
+  }
 
-    if (length(colour) > 1) {
-      alpha <- rep(alpha, length.out = length(colour))
-    } else {
-      colour <- rep(colour, length.out = length(alpha))
+  if (length(colour) != length(alpha)) {
+    if (length(colour) > 1 && length(alpha) > 1) {
+      stop("Only one of colour and alpha can be vectorised")
     }
   }
 
-  rgb <- farver::decode_colour(colour, alpha = TRUE)
-  rgb[!is.na(alpha), 4] <- alpha[!is.na(alpha)]
-
-  farver::encode_colour(rgb, rgb[, 4])
+  if (color_fmt == "character") {
+    if (is.integer(colour)) {
+      colour <- farver::decode_native(colour)
+    }
+    if (length(colour) == 1) {
+      colour <- rep(colour, length.out = length(alpha))
+    }
+    farver::set_channel(colour, "alpha", alpha, skip_na_values = TRUE)
+  } else {
+    if (is.character(colour)) {
+      colour <- farver::encode_native(colour)
+    }
+    if (length(colour) == 1) {
+      colour <- rep(colour, length.out = length(alpha))
+    }
+    farver::set_channel_native(colour, "alpha", alpha, skip_na_values = TRUE)
+  }
 }
 
 #' Show colours

--- a/man/alpha.Rd
+++ b/man/alpha.Rd
@@ -4,13 +4,17 @@
 \alias{alpha}
 \title{Modify colour transparency}
 \usage{
-alpha(colour, alpha = NA)
+alpha(colour, alpha = NA, color_fmt = "character")
 }
 \arguments{
 \item{colour}{colour}
 
 \item{alpha}{new alpha level in [0,1].  If alpha is \code{NA},
 existing alpha values are preserved.}
+
+\item{color_fmt}{A string, whether the output should be a character vector
+with colours (\code{"character"}) or an integer vector in the native color
+format (\code{"native"})}
 }
 \description{
 Vectorised in both colour and alpha.


### PR DESCRIPTION
This pull request is on top of:
- https://github.com/thomasp85/farver/pull/40

It uses the improvements on `farver` to make `scales::alpha()` much faster, avoiding the intermediate step of the numeric matrix.

Besides, it adds an additional parameter `color_fmt` to choose between a `"character"` output format or the `"native"` output format, used in nativeRaster objects.

Proposed NEWS entry (not added to avoid trivial conflicts):

```
  * `alpha()` performance improvements. Added support for `native` color format (#, @zeehio)
```

Related to:

- https://github.com/tidyverse/ggplot2/issues/4989