### PR TITLE
Add na.color support to gradient_n_pal, div_gradient_pal, seq_gradient_pal

### DIFF
--- a/R/pal-gradient.r
+++ b/R/pal-gradient.r
@@ -7,13 +7,15 @@
 #'   to map an arbitrary range to between 0 and 1.
 #' @param space colour space in which to calculate gradient. Must be "Lab" -
 #'   other values are deprecated.
+#' @param na.color The color to use for missing values. By default missing
+#'   values are left missing.
 #' @export
 
-gradient_n_pal <- function(colours, values = NULL, space = "Lab") {
+gradient_n_pal <- function(colours, values = NULL, space = "Lab", na.color = NA) {
   if (!identical(space, "Lab")) {
     lifecycle::deprecate_warn("0.3.0", "gradient_n_pal(space = 'only supports be \"Lab\"')")
   }
-  ramp <- colour_ramp(colours)
+  ramp <- colour_ramp(colours, na.color = na.color)
   force(values)
 
   function(x) {
@@ -49,8 +51,8 @@ gradient_n_pal <- function(colours, values = NULL, space = "Lab") {
 #' pal <- div_gradient_pal(low = mnsl(complement("10R 4/6"), fix = TRUE))
 #' image(r, col = pal(seq(0, 1, length.out = 100)))
 #' @importFrom munsell mnsl
-div_gradient_pal <- function(low = mnsl("10B 4/6"), mid = mnsl("N 8/0"), high = mnsl("10R 4/6"), space = "Lab") {
-  gradient_n_pal(c(low, mid, high), space = space)
+div_gradient_pal <- function(low = mnsl("10B 4/6"), mid = mnsl("N 8/0"), high = mnsl("10R 4/6"), space = "Lab", na.color = NA) {
+  gradient_n_pal(c(low, mid, high), space = space, na.color = na.color)
 }
 
 #' Sequential colour gradient palette (continuous)
@@ -66,6 +68,6 @@ div_gradient_pal <- function(low = mnsl("10B 4/6"), mid = mnsl("N 8/0"), high = 
 #'
 #' library(munsell)
 #' show_col(seq_gradient_pal("white", mnsl("10R 4/6"))(x))
-seq_gradient_pal <- function(low = mnsl("10B 4/6"), high = mnsl("10R 4/6"), space = "Lab") {
-  gradient_n_pal(c(low, high), space = space)
+seq_gradient_pal <- function(low = mnsl("10B 4/6"), high = mnsl("10R 4/6"), space = "Lab", na.color = NA) {
+  gradient_n_pal(c(low, high), space = space, na.color = na.color)
 }

--- a/man/div_gradient_pal.Rd
+++ b/man/div_gradient_pal.Rd
@@ -8,7 +8,8 @@ div_gradient_pal(
   low = mnsl("10B 4/6"),
   mid = mnsl("N 8/0"),
   high = mnsl("10R 4/6"),
-  space = "Lab"
+  space = "Lab",
+  na.color = NA
 )
 }
 \arguments{
@@ -20,6 +21,9 @@ div_gradient_pal(
 
 \item{space}{colour space in which to calculate gradient. Must be "Lab" -
 other values are deprecated.}
+
+\item{na.color}{The color to use for missing values. By default missing
+values are left missing.}
 }
 \description{
 Diverging colour gradient (continuous).

--- a/man/gradient_n_pal.Rd
+++ b/man/gradient_n_pal.Rd
@@ -4,7 +4,7 @@
 \alias{gradient_n_pal}
 \title{Arbitrary colour gradient palette (continuous)}
 \usage{
-gradient_n_pal(colours, values = NULL, space = "Lab")
+gradient_n_pal(colours, values = NULL, space = "Lab", na.color = NA)
 }
 \arguments{
 \item{colours}{vector of colours}
@@ -16,6 +16,9 @@ to map an arbitrary range to between 0 and 1.}
 
 \item{space}{colour space in which to calculate gradient. Must be "Lab" -
 other values are deprecated.}
+
+\item{na.color}{The color to use for missing values. By default missing
+values are left missing.}
 }
 \description{
 Arbitrary colour gradient palette (continuous)

--- a/man/seq_gradient_pal.Rd
+++ b/man/seq_gradient_pal.Rd
@@ -4,7 +4,12 @@
 \alias{seq_gradient_pal}
 \title{Sequential colour gradient palette (continuous)}
 \usage{
-seq_gradient_pal(low = mnsl("10B 4/6"), high = mnsl("10R 4/6"), space = "Lab")
+seq_gradient_pal(
+  low = mnsl("10B 4/6"),
+  high = mnsl("10R 4/6"),
+  space = "Lab",
+  na.color = NA
+)
 }
 \arguments{
 \item{low}{colour for low end of gradient.}
@@ -13,6 +18,9 @@ seq_gradient_pal(low = mnsl("10B 4/6"), high = mnsl("10R 4/6"), space = "Lab")
 
 \item{space}{colour space in which to calculate gradient. Must be "Lab" -
 other values are deprecated.}
+
+\item{na.color}{The color to use for missing values. By default missing
+values are left missing.}
 }
 \description{
 Sequential colour gradient palette (continuous)


### PR DESCRIPTION
`colour_ramp` already supports `na.color`, so this pull request just adds the ability to pass it to `gradient_n_pal` and friends

- https://github.com/r-lib/scales/blob/b3df2fb6efd5b440377b0699d3830f1082fa3140/R/colour-ramp.R#L35

This is related to:

- https://github.com/tidyverse/ggplot2/issues/4989

Proposed NEWS entry:

```
 * `gradient_n_pal`, `div_gradient_pal` and `seq_gradient_pal` accept a `na.color` (#, @zeehio)
```