### PR TITLE
Add palette capabilities: may_return_NA, accepts_native_output

### DIFF
--- a/R/colour-ramp.R
+++ b/R/colour-ramp.R
@@ -67,12 +67,17 @@ colour_ramp <- function(colors, na.color = NA, alpha = TRUE) {
   }
 
   structure(
-    function(x) {
-      lab_out <- cbind(l_interp(x), u_interp(x), v_interp(x))
-      out <- farver::encode_colour(lab_out, alpha = alpha_interp(x), from = "lab")
-      out[is.na(out)] <- na.color
+    function(x, color_fmt = "character") {
+      lab_out <- list(l_interp(x), u_interp(x), v_interp(x))
+      if (color_fmt == "character") {
+        out <- farver::encode_colour(lab_out, alpha = alpha_interp(x), from = "lab", na_value = na.color)
+      } else {
+        out <- farver::encode_native(lab_out, alpha = alpha_interp(x), from = "lab", na_value = na.color)
+      }
       out
     },
-    safe_palette_func = TRUE
+    safe_palette_func = TRUE,
+    accepts_native_output = TRUE,
+    may_return_NA = is.na(na.color)
   )
 }

--- a/R/pal-gradient.r
+++ b/R/pal-gradient.r
@@ -18,19 +18,25 @@ gradient_n_pal <- function(colours, values = NULL, space = "Lab", na.color = NA)
   ramp <- colour_ramp(colours, na.color = na.color)
   force(values)
 
-  function(x) {
-    if (length(x) == 0) {
-      return(character())
-    }
-
-    if (!is.null(values)) {
-      xs <- seq(0, 1, length.out = length(values))
-      f <- stats::approxfun(values, xs)
-      x <- f(x)
-    }
-
-    ramp(x)
-  }
+  structure(
+    function(x, color_fmt = "character") {
+      if (length(x) == 0) {
+        if (color_fmt == "character") {
+          return(character())
+        } else {
+          return(integer())
+        }
+      }
+      if (!is.null(values)) {
+        xs <- seq(0, 1, length.out = length(values))
+        f <- stats::approxfun(values, xs)
+        x <- f(x)
+      }
+      ramp(x, color_fmt = color_fmt)
+    },
+    accepts_native_output = TRUE,
+    may_return_NA = is.na(na.color)
+  )
 }
 
 #' Diverging colour gradient (continuous).

--- a/R/pal-gradient.r
+++ b/R/pal-gradient.r
@@ -7,13 +7,15 @@
 #'   to map an arbitrary range to between 0 and 1.
 #' @param space colour space in which to calculate gradient. Must be "Lab" -
 #'   other values are deprecated.
+#' @param na.color The color to use for missing values. By default missing
+#'   values are left missing.
 #' @export
 
-gradient_n_pal <- function(colours, values = NULL, space = "Lab") {
+gradient_n_pal <- function(colours, values = NULL, space = "Lab", na.color = NA) {
   if (!identical(space, "Lab")) {
     lifecycle::deprecate_warn("0.3.0", "gradient_n_pal(space = 'only supports be \"Lab\"')")
   }
-  ramp <- colour_ramp(colours)
+  ramp <- colour_ramp(colours, na.color = na.color)
   force(values)
 
   function(x) {
@@ -49,8 +51,8 @@ gradient_n_pal <- function(colours, values = NULL, space = "Lab") {
 #' pal <- div_gradient_pal(low = mnsl(complement("10R 4/6"), fix = TRUE))
 #' image(r, col = pal(seq(0, 1, length.out = 100)))
 #' @importFrom munsell mnsl
-div_gradient_pal <- function(low = mnsl("10B 4/6"), mid = mnsl("N 8/0"), high = mnsl("10R 4/6"), space = "Lab") {
-  gradient_n_pal(c(low, mid, high), space = space)
+div_gradient_pal <- function(low = mnsl("10B 4/6"), mid = mnsl("N 8/0"), high = mnsl("10R 4/6"), space = "Lab", na.color = NA) {
+  gradient_n_pal(c(low, mid, high), space = space, na.color = na.color)
 }
 
 #' Sequential colour gradient palette (continuous)
@@ -66,6 +68,6 @@ div_gradient_pal <- function(low = mnsl("10B 4/6"), mid = mnsl("N 8/0"), high = 
 #'
 #' library(munsell)
 #' show_col(seq_gradient_pal("white", mnsl("10R 4/6"))(x))
-seq_gradient_pal <- function(low = mnsl("10B 4/6"), high = mnsl("10R 4/6"), space = "Lab") {
-  gradient_n_pal(c(low, high), space = space)
+seq_gradient_pal <- function(low = mnsl("10B 4/6"), high = mnsl("10R 4/6"), space = "Lab", na.color = NA) {
+  gradient_n_pal(c(low, high), space = space, na.color = na.color)
 }

--- a/man/div_gradient_pal.Rd
+++ b/man/div_gradient_pal.Rd
@@ -8,7 +8,8 @@ div_gradient_pal(
   low = mnsl("10B 4/6"),
   mid = mnsl("N 8/0"),
   high = mnsl("10R 4/6"),
-  space = "Lab"
+  space = "Lab",
+  na.color = NA
 )
 }
 \arguments{
@@ -20,6 +21,9 @@ div_gradient_pal(
 
 \item{space}{colour space in which to calculate gradient. Must be "Lab" -
 other values are deprecated.}
+
+\item{na.color}{The color to use for missing values. By default missing
+values are left missing.}
 }
 \description{
 Diverging colour gradient (continuous).

--- a/man/gradient_n_pal.Rd
+++ b/man/gradient_n_pal.Rd
@@ -4,7 +4,7 @@
 \alias{gradient_n_pal}
 \title{Arbitrary colour gradient palette (continuous)}
 \usage{
-gradient_n_pal(colours, values = NULL, space = "Lab")
+gradient_n_pal(colours, values = NULL, space = "Lab", na.color = NA)
 }
 \arguments{
 \item{colours}{vector of colours}
@@ -16,6 +16,9 @@ to map an arbitrary range to between 0 and 1.}
 
 \item{space}{colour space in which to calculate gradient. Must be "Lab" -
 other values are deprecated.}
+
+\item{na.color}{The color to use for missing values. By default missing
+values are left missing.}
 }
 \description{
 Arbitrary colour gradient palette (continuous)

--- a/man/seq_gradient_pal.Rd
+++ b/man/seq_gradient_pal.Rd
@@ -4,7 +4,12 @@
 \alias{seq_gradient_pal}
 \title{Sequential colour gradient palette (continuous)}
 \usage{
-seq_gradient_pal(low = mnsl("10B 4/6"), high = mnsl("10R 4/6"), space = "Lab")
+seq_gradient_pal(
+  low = mnsl("10B 4/6"),
+  high = mnsl("10R 4/6"),
+  space = "Lab",
+  na.color = NA
+)
 }
 \arguments{
 \item{low}{colour for low end of gradient.}
@@ -13,6 +18,9 @@ seq_gradient_pal(low = mnsl("10B 4/6"), high = mnsl("10R 4/6"), space = "Lab")
 
 \item{space}{colour space in which to calculate gradient. Must be "Lab" -
 other values are deprecated.}
+
+\item{na.color}{The color to use for missing values. By default missing
+values are left missing.}
 }
 \description{
 Sequential colour gradient palette (continuous)


### PR DESCRIPTION
This pull request (on top of #371) extends the definition of a palette by adding attributes to the palette function.

These attributes may be ignored if you don't care for them, but they can be used by the palette consumer (e.g. ggplot2) to be faster.

We define two new attributes on `colour_ramp`, `gradient_n_pal`, `div_gradient_pal` and `seq_gradient_pal`.

- `may_return_NA`: If this attribute is set to `FALSE`, the palette consumer can safely assume that the palette won't return missing values (therefore skipping any check).
- `accepts_native_output`: if this attribute is set to `TRUE`, the palette consumer can safely assume that the palette accepts an additional keyword argument named `color_fmt` which can take two values: `"character"` and `"native"`. The palette consumer can call the palette with `color_fmt = "native"` to get colours in native format (as used in nativeRaster objects). The palette consumer can avoid the intermediate character representation of colours.

This is related to:
- https://github.com/tidyverse/ggplot2/issues/4989

Proposed NEWS entry:

```
 * `colour_ramp`, `gradient_n_pal`, `div_gradient_pal` and `seq_gradient_pal` -based palettes 
   include additional attributes to let its user know that they are able to output colours in native
   format and whether or not they return missing values (#372, @zeehio)
```