### PR TITLE
Correct domain calculation for compose_trans

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@
 * Add an inverse (area) hyperbolic sine transformation `asinh_trans()`, which
   provides a logarithm-like transformation of a space, but which accommodates
   negative values (#297)
+* Correct the domain calculation for `compose_trans()` (@mjskay, #408).
 
 # scales 1.2.1
 

--- a/tests/testthat/_snaps/trans-compose.md
+++ b/tests/testthat/_snaps/trans-compose.md
@@ -6,7 +6,7 @@
       Error in `compose_trans()`:
       ! `compose_trans()` must include at least 1 transformer to compose
     Code
-      compose_trans("reverse", "log10")
+      compose_trans("sqrt", "reverse", "log10")
     Condition
       Error in `compose_trans()`:
       ! Sequence of transformations yields invalid domain

--- a/tests/testthat/test-trans-compose.R
+++ b/tests/testthat/test-trans-compose.R
@@ -12,6 +12,15 @@ test_that("uses breaks from first transformer", {
 test_that("produces informative errors", {
   expect_snapshot(error = TRUE, {
     compose_trans()
-    compose_trans("reverse", "log10")
+    compose_trans("sqrt", "reverse", "log10")
   })
+})
+
+test_that("produces correct domains", {
+  expect_equal(compose_trans("sqrt", "reverse")$domain, c(0, Inf))
+  expect_equal(compose_trans("sqrt", "log")$domain, c(0, Inf))
+  expect_equal(compose_trans("log", "log")$domain, c(1, Inf))
+  expect_equal(compose_trans("reverse", "log")$domain, c(-Inf, 0))
+  expect_equal(compose_trans("reverse", "logit", "log")$domain, c(-1, -0.5))
+  expect_error(compose_trans("sqrt", "reverse", "log")$domain, "invalid domain")
 })


### PR DESCRIPTION
This PR corrects the domain calculations for `compose_trans()`, which appear to be incorrect. 

## The problem

Currently, `compose_trans()` pushes the domain of the first function through all transformations to calculate the domain. This procedure, when it works (i.e. if the range of each transformation in the chain is contained within the domain of the next one), yields the *range* of the composed set of transformations, not the domain.

This leads to incorrect domains; e.g.:

```r
compose_trans("sqrt", "reverse")$domain
## [1] -Inf    0
```

The correct domain here is just the domain of `sqrt()`, which is `c(0, Inf)`. We can see this by plotting it:

```r
plot(compose_trans("sqrt", "reverse"), xlim = c(-1,4))
## Warning message:
## In trans$transform(x) : NaNs produced
```
![image](https://github.com/r-lib/scales/assets/6345019/c7793496-2d90-4607-a73e-06a3ce7d50a8)

This also leads to `compose_trans()` incorrectly erroring on valid compositions; e.g.:

```r
compose_trans("reverse", "log")
## Error in `compose_trans()`:
## ! Sequence of transformations yields invalid domain
## Run `rlang::last_trace()` to see where the error occurred.
```

Yet, this should be a valid transformation, just with the domain `c(-Inf, 0)` instead of the original domain of `c(0, Inf)` (this also offers a solution to the question about reverse + log in #393: the transformation is valid so long as the domain is correctly calculated).

## The solution

This PR adjusts the domain calculation to push the first domain forward through the transformations, intersecting it with the domains of each transformation along the way, then pushing the resulting range back through the inverses to get the domain.

On the above two examples, with this PR, we have:

```r
compose_trans("sqrt", "reverse")$domain
## [1]   0 Inf
```

and

```r
compose_trans("reverse", "log")$domain
## [1]    -Inf -1e-100
```
