### PR TITLE
Propagate call for error messages

### DIFF
--- a/R/range.R
+++ b/R/range.R
@@ -18,9 +18,10 @@ DiscreteRange <- R6::R6Class(
   inherit = Range,
   list(
     factor = NULL,
-    train = function(x, drop = FALSE, na.rm = FALSE) {
+    train = function(x, drop = FALSE, na.rm = FALSE, call = caller_env()) {
       self$factor <- self$factor %||% is.factor(x)
-      self$range <- train_discrete(x, self$range, drop, na.rm, self$factor)
+      self$range <- train_discrete(x, self$range, drop, na.rm,
+                                   self$factor, call = call)
     },
     reset = function() {
       self$range <- NULL
@@ -35,7 +36,9 @@ ContinuousRange <- R6::R6Class(
   "ContinuousRange",
   inherit = Range,
   list(
-    train = function(x) self$range <- train_continuous(x, self$range),
+    train = function(x, call = caller_env()) {
+      self$range <- train_continuous(x, self$range, call = call)
+    },
     reset = function() self$range <- NULL
   )
 )

--- a/R/scale-continuous.R
+++ b/R/scale-continuous.R
@@ -37,13 +37,13 @@ cscale <- function(x, palette, na.value = NA_real_, trans = transform_identity()
 #'
 #' @inheritParams train_discrete
 #' @export
-train_continuous <- function(new, existing = NULL) {
+train_continuous <- function(new, existing = NULL, call = caller_env()) {
   if (is.null(new)) {
     return(existing)
   }
 
   if (is.factor(new) || !typeof(new) %in% c("integer", "double")) {
-    cli::cli_abort("Discrete value supplied to a continuous scale")
+    cli::cli_abort("Discrete value supplied to a continuous scale", call = call)
   }
 
   # Needs casting to numeric because some `new` vectors can misbehave when

--- a/R/scale-discrete.R
+++ b/R/scale-discrete.R
@@ -26,13 +26,14 @@ is.discrete <- function(x) {
 #' @param na.rm If `TRUE`, will remove missing values
 #' @param fct Treat `existing` as if it came from a factor (ie. don't sort the range)
 #' @export
-train_discrete <- function(new, existing = NULL, drop = FALSE, na.rm = FALSE, fct = NA) {
+train_discrete <- function(new, existing = NULL, drop = FALSE,
+                           na.rm = FALSE, fct = NA, call = caller_env()) {
   if (is.null(new)) {
     return(existing)
   }
 
   if (!is.discrete(new)) {
-    cli::cli_abort("Continuous value supplied to a discrete scale")
+    cli::cli_abort("Continuous value supplied to a discrete scale", call = call)
   }
   discrete_range(existing, new, drop = drop, na.rm = na.rm, fct = fct)
 }


### PR DESCRIPTION
This PR aims to fix #379.

Briefly, it adds a `call` argument to range training that is used to communicate error messages.
Short demo:

``` r
devtools::load_all("~/packages/scales")
#> ℹ Loading scales

i_train_ranges <- function(x) {
  range <- ContinuousRange$new()
  range$train(x, call = current_call())
  range$range
}

i_train_ranges(1:10)
#> [1]  1 10
i_train_ranges(c("foo", "bar"))
#> Error in `i_train_ranges()`:
#> ! Discrete value supplied to a continuous scale
```

<sup>Created on 2023-12-22 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
