### PR TITLE
fix bug in `label_number` when `scale_cut` argument is provided (#413)

### DIFF
--- a/R/label-number.R
+++ b/R/label-number.R
@@ -350,6 +350,7 @@ scale_cut <- function(x, breaks, scale = 1, accuracy = NULL, suffix = "") {
   if (any(bad_break)) {
     # If the break below result in a perfect cut, prefer it
     lower_break <- breaks[match(break_suffix[bad_break], names(breaks)) - 1]
+    lower_break[lower_break == 0] <- 1  # Avoid choosing a non-existent break
     improved_break <- (x[bad_break] * scale / lower_break) %% 1 == 0
     # Unless the break below is a power of 10 change (1.25 is as good as 1250)
     power10_break <- log10(breaks[break_suffix[bad_break]] / lower_break) %% 1 == 0

--- a/tests/testthat/test-label-number.R
+++ b/tests/testthat/test-label-number.R
@@ -179,6 +179,11 @@ test_that("scale_cut prefers clean cuts", {
   x <- c(518400, 691200)
   # prefers days over week in second element
   expect_equal(number(x, scale_cut = cut_time_scale()), c("6d", "8d"))
+
+  # do not select off-scale breaks
+  x <- c(0, 500, 1500, 2000, 2500)
+  expect_equal(number(x, scale_cut = cut_short_scale()), c("0", "500", "1.5K", "2.0K", "2.5K"))
+
 })
 
 test_that("built-in functions return expected values", {


### PR DESCRIPTION
This pull request resolves #413, implementing the fix proposed by @jbengler ([link](https://github.com/r-lib/scales/issues/413#issuecomment-1859304601))

Behaviour in 1.3.0:

```
> scales::label_number(scale_cut = scales::cut_short_scale())(c(0,500,1500,2000,2500))
Error in break_suffix[bad_break][improved_break & !power10_break] <- names(lower_break[improved_break &  : 
  NAs are not allowed in subscripted assignments
```

Behaviour after change (as expected):

```
> scales::label_number(scale_cut = scales::cut_short_scale())(c(0,500,1500,2000,2500))
[1] "0"    "500"  "1.5K" "2.0K" "2.5K"
```

This change does not break any package tests, and I have added an additional test against this behaviour.
```
[ FAIL 0 | WARN 0 | SKIP 0 | PASS 597 ]
```

