### PR TITLE
Update label-date documentation

### DIFF
--- a/R/label-date.R
+++ b/R/label-date.R
@@ -11,10 +11,10 @@
 #' suffix to the input (ns, us, ms, s, m, h, d, w).
 #'
 #' @inherit label_number return
-#' @param format For `date_format()` and `time_format()` a date/time format
+#' @param format For `label_date()` and `label_time()` a date/time format
 #'   string using standard POSIX specification.  See [strptime()] for details.
 #'
-#'   For `date_short()` a character vector of length 4 giving the format
+#'   For `label_date_short()` a character vector of length 4 giving the format
 #'   components to use for year, month, day, and hour respectively.
 #' @param tz a time zone name, see [timezones()]. Defaults
 #'   to UTC
@@ -31,9 +31,9 @@
 #'
 #' two_months <- date_range("2020-05-01", 60)
 #' demo_datetime(two_months)
-#' demo_datetime(two_months, labels = date_format("%m/%d"))
-#' demo_datetime(two_months, labels = date_format("%e %b", locale = "fr"))
-#' demo_datetime(two_months, labels = date_format("%e %B", locale = "es"))
+#' demo_datetime(two_months, labels = label_date("%m/%d"))
+#' demo_datetime(two_months, labels = label_date("%e %b", locale = "fr"))
+#' demo_datetime(two_months, labels = label_date("%e %B", locale = "es"))
 #' # ggplot2 provides a short-hand:
 #' demo_datetime(two_months, date_labels = "%m/%d")
 #'

--- a/man/date_format.Rd
+++ b/man/date_format.Rd
@@ -10,10 +10,10 @@ date_format(format = "\%Y-\%m-\%d", tz = "UTC", locale = NULL)
 time_format(format = "\%H:\%M:\%S", tz = "UTC", locale = NULL)
 }
 \arguments{
-\item{format}{For \code{date_format()} and \code{time_format()} a date/time format
+\item{format}{For \code{label_date()} and \code{label_time()} a date/time format
 string using standard POSIX specification.  See \code{\link[=strptime]{strptime()}} for details.
 
-For \code{date_short()} a character vector of length 4 giving the format
+For \code{label_date_short()} a character vector of length 4 giving the format
 components to use for year, month, day, and hour respectively.}
 
 \item{tz}{a time zone name, see \code{\link[=timezones]{timezones()}}. Defaults

--- a/man/label_date.Rd
+++ b/man/label_date.Rd
@@ -20,10 +20,10 @@ label_timespan(
 )
 }
 \arguments{
-\item{format}{For \code{date_format()} and \code{time_format()} a date/time format
+\item{format}{For \code{label_date()} and \code{label_time()} a date/time format
 string using standard POSIX specification.  See \code{\link[=strptime]{strptime()}} for details.
 
-For \code{date_short()} a character vector of length 4 giving the format
+For \code{label_date_short()} a character vector of length 4 giving the format
 components to use for year, month, day, and hour respectively.}
 
 \item{tz}{a time zone name, see \code{\link[=timezones]{timezones()}}. Defaults
@@ -109,9 +109,9 @@ date_range <- function(start, days) {
 
 two_months <- date_range("2020-05-01", 60)
 demo_datetime(two_months)
-demo_datetime(two_months, labels = date_format("\%m/\%d"))
-demo_datetime(two_months, labels = date_format("\%e \%b", locale = "fr"))
-demo_datetime(two_months, labels = date_format("\%e \%B", locale = "es"))
+demo_datetime(two_months, labels = label_date("\%m/\%d"))
+demo_datetime(two_months, labels = label_date("\%e \%b", locale = "fr"))
+demo_datetime(two_months, labels = label_date("\%e \%B", locale = "es"))
 # ggplot2 provides a short-hand:
 demo_datetime(two_months, date_labels = "\%m/\%d")
 


### PR DESCRIPTION
The docs were confusingly referencing the superseded `date_format` `time_format` and `date_short` functions.