### PR TITLE
fix typo in documentation for `label_pvalue()`

### DIFF
--- a/R/label-pvalue.R
+++ b/R/label-pvalue.R
@@ -4,8 +4,8 @@
 #'
 #' @inherit label_number return params
 #' @param prefix A character vector of length 3 giving the prefixes to
-#'   put in front of numbers. The default values are `c("<", "", ">")`
-#'   if `add_p` is `FALSE` and `c("p<", "p=", "p>")` if `TRUE`.
+#'   put in front of numbers. The default values are `c("p<", "p=", "p>")`
+#'   if `add_p` is `TRUE` and `c("<", "", ">")` if `FALSE`.
 #' @param add_p Add "p=" before the value?
 #' @export
 #' @family labels for continuous scales

--- a/R/label-pvalue.R
+++ b/R/label-pvalue.R
@@ -5,7 +5,7 @@
 #' @inherit label_number return params
 #' @param prefix A character vector of length 3 giving the prefixes to
 #'   put in front of numbers. The default values are `c("<", "", ">")`
-#'   if `add_p` is `TRUE` and `c("p<", "p=", "p>")` if `FALSE`.
+#'   if `add_p` is `FALSE` and `c("p<", "p=", "p>")` if `TRUE`.
 #' @param add_p Add "p=" before the value?
 #' @export
 #' @family labels for continuous scales


### PR DESCRIPTION
The documentation of the `prefix` argument appears to be opposite of the actual code; here's a PR to fix.