### PR TITLE
Update warning message for shape overuse

### DIFF
--- a/R/pal-shape.r
+++ b/R/pal-shape.r
@@ -8,7 +8,7 @@ pal_shape <- function(solid = TRUE) {
     if (n > 6) {
       cli::cli_warn(c(
         "The shape palette can deal with a maximum of 6 discrete values because more than 6 becomes difficult to discriminate",
-        i = "you have requested {n} values. Consider specifying shapes manually if you need that many have them."
+        i = "you have requested {n} values. Consider specifying shapes manually if you need that many of them."
       ))
     }
 


### PR DESCRIPTION
I accidentally transposed a couple of aesthetic mappings while constructing a plot yesterday and was (rightfully) warned about my request for 25 different shapes. However, I noticed that the wording of the warning was a little strange/confusing (emphasis mine):

> you have requested 25 values. Consider specifying shapes manually if you need **that many have them**.

It looks like this happened unintentionally in 45ca806b: the message originally read "if you must have them." This PR rewords it to "if you need that many of them," but I'm not attached to this particular phrasing.