### PR TITLE
fix typos; spelling and missing bracket

### DIFF
--- a/R/label-date.R
+++ b/R/label-date.R
@@ -151,7 +151,7 @@ format_dt <- function(x, format, tz = "UTC", locale = NULL) {
 #' `r lifecycle::badge("superseded")`
 #'
 #' These functions are kept for backward compatibility; you should switch
-#' to [label_date()/[label_time()] for new code.
+#' to [label_date()]/[label_time()] for new code.
 #'
 #' @keywords internal
 #' @export

--- a/R/label-number.R
+++ b/R/label-number.R
@@ -1,6 +1,6 @@
 #' Label numbers in decimal format (e.g. 0.12, 1,234)
 #'
-#' Use `label_number()` force decimal display of numbers (i.e. don't use
+#' Use `label_number()` to force decimal display of numbers (i.e. don't use
 #' [scientific][label_scientific] notation). `label_comma()` is a special case
 #' that inserts a comma every three digits.
 #'
@@ -40,7 +40,7 @@
 #'     right-justified.
 #' @param style_negative A string that determines the style of negative numbers:
 #'
-#'   * `"hyphen"` (the default): preceded by a standard hypen `-`, e.g. `-1`.
+#'   * `"hyphen"` (the default): preceded by a standard hyphen `-`, e.g. `-1`.
 #'   * `"minus"`, uses a proper Unicode minus symbol. This is a typographical
 #'      nicety that ensures `-` aligns with the horizontal bar of the
 #'      the horizontal bar of `+`.

--- a/R/pal-dichromat.R
+++ b/R/pal-dichromat.R
@@ -8,7 +8,7 @@
 #'   show_col(pal_dichromat("BluetoOrange.10")(10))
 #'   show_col(pal_dichromat("BluetoOrange.10")(5))
 #'
-#'   # Can use with gradient_n to create a continous gradient
+#'   # Can use with gradient_n to create a continuous gradient
 #'   cols <- pal_dichromat("DarkRedtoBlue.12")(12)
 #'   show_col(pal_gradient_n(cols)(seq(0, 1, length.out = 30)))
 #' }

--- a/man/comma.Rd
+++ b/man/comma.Rd
@@ -89,7 +89,7 @@ right-justified.
 
 \item{style_negative}{A string that determines the style of negative numbers:
 \itemize{
-\item \code{"hyphen"} (the default): preceded by a standard hypen \code{-}, e.g. \code{-1}.
+\item \code{"hyphen"} (the default): preceded by a standard hyphen \code{-}, e.g. \code{-1}.
 \item \code{"minus"}, uses a proper Unicode minus symbol. This is a typographical
 nicety that ensures \code{-} aligns with the horizontal bar of the
 the horizontal bar of \code{+}.

--- a/man/date_format.Rd
+++ b/man/date_format.Rd
@@ -28,6 +28,6 @@ can see a complete list of supported locales with
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
 
 These functions are kept for backward compatibility; you should switch
-to [label_date()/\code{\link[=label_time]{label_time()}} for new code.
+to \code{\link[=label_date]{label_date()}}/\code{\link[=label_time]{label_time()}} for new code.
 }
 \keyword{internal}

--- a/man/label_bytes.Rd
+++ b/man/label_bytes.Rd
@@ -49,7 +49,7 @@ right-justified.
 }}
     \item{\code{style_negative}}{A string that determines the style of negative numbers:
 \itemize{
-\item \code{"hyphen"} (the default): preceded by a standard hypen \code{-}, e.g. \code{-1}.
+\item \code{"hyphen"} (the default): preceded by a standard hyphen \code{-}, e.g. \code{-1}.
 \item \code{"minus"}, uses a proper Unicode minus symbol. This is a typographical
 nicety that ensures \code{-} aligns with the horizontal bar of the
 the horizontal bar of \code{+}.

--- a/man/label_currency.Rd
+++ b/man/label_currency.Rd
@@ -51,7 +51,7 @@ right-justified.
 }}
     \item{\code{style_negative}}{A string that determines the style of negative numbers:
 \itemize{
-\item \code{"hyphen"} (the default): preceded by a standard hypen \code{-}, e.g. \code{-1}.
+\item \code{"hyphen"} (the default): preceded by a standard hyphen \code{-}, e.g. \code{-1}.
 \item \code{"minus"}, uses a proper Unicode minus symbol. This is a typographical
 nicety that ensures \code{-} aligns with the horizontal bar of the
 the horizontal bar of \code{+}.

--- a/man/label_date.Rd
+++ b/man/label_date.Rd
@@ -70,7 +70,7 @@ right-justified.
 }}
     \item{\code{style_negative}}{A string that determines the style of negative numbers:
 \itemize{
-\item \code{"hyphen"} (the default): preceded by a standard hypen \code{-}, e.g. \code{-1}.
+\item \code{"hyphen"} (the default): preceded by a standard hyphen \code{-}, e.g. \code{-1}.
 \item \code{"minus"}, uses a proper Unicode minus symbol. This is a typographical
 nicety that ensures \code{-} aligns with the horizontal bar of the
 the horizontal bar of \code{+}.

--- a/man/label_number.Rd
+++ b/man/label_number.Rd
@@ -66,7 +66,7 @@ right-justified.
 
 \item{style_negative}{A string that determines the style of negative numbers:
 \itemize{
-\item \code{"hyphen"} (the default): preceded by a standard hypen \code{-}, e.g. \code{-1}.
+\item \code{"hyphen"} (the default): preceded by a standard hyphen \code{-}, e.g. \code{-1}.
 \item \code{"minus"}, uses a proper Unicode minus symbol. This is a typographical
 nicety that ensures \code{-} aligns with the horizontal bar of the
 the horizontal bar of \code{+}.
@@ -107,7 +107,7 @@ they work similarly for all scales, including those that generate legends
 rather than axes.
 }
 \description{
-Use \code{label_number()} force decimal display of numbers (i.e. don't use
+Use \code{label_number()} to force decimal display of numbers (i.e. don't use
 \link[=label_scientific]{scientific} notation). \code{label_comma()} is a special case
 that inserts a comma every three digits.
 }

--- a/man/label_number_si.Rd
+++ b/man/label_number_si.Rd
@@ -42,7 +42,7 @@ right-justified.
 }}
     \item{\code{style_negative}}{A string that determines the style of negative numbers:
 \itemize{
-\item \code{"hyphen"} (the default): preceded by a standard hypen \code{-}, e.g. \code{-1}.
+\item \code{"hyphen"} (the default): preceded by a standard hyphen \code{-}, e.g. \code{-1}.
 \item \code{"minus"}, uses a proper Unicode minus symbol. This is a typographical
 nicety that ensures \code{-} aligns with the horizontal bar of the
 the horizontal bar of \code{+}.

--- a/man/label_ordinal.Rd
+++ b/man/label_ordinal.Rd
@@ -54,7 +54,7 @@ right-justified.
 }}
     \item{\code{style_negative}}{A string that determines the style of negative numbers:
 \itemize{
-\item \code{"hyphen"} (the default): preceded by a standard hypen \code{-}, e.g. \code{-1}.
+\item \code{"hyphen"} (the default): preceded by a standard hyphen \code{-}, e.g. \code{-1}.
 \item \code{"minus"}, uses a proper Unicode minus symbol. This is a typographical
 nicety that ensures \code{-} aligns with the horizontal bar of the
 the horizontal bar of \code{+}.

--- a/man/label_percent.Rd
+++ b/man/label_percent.Rd
@@ -55,7 +55,7 @@ right-justified.
 }}
     \item{\code{style_negative}}{A string that determines the style of negative numbers:
 \itemize{
-\item \code{"hyphen"} (the default): preceded by a standard hypen \code{-}, e.g. \code{-1}.
+\item \code{"hyphen"} (the default): preceded by a standard hyphen \code{-}, e.g. \code{-1}.
 \item \code{"minus"}, uses a proper Unicode minus symbol. This is a typographical
 nicety that ensures \code{-} aligns with the horizontal bar of the
 the horizontal bar of \code{+}.

--- a/man/number.Rd
+++ b/man/number.Rd
@@ -66,7 +66,7 @@ right-justified.
 
 \item{style_negative}{A string that determines the style of negative numbers:
 \itemize{
-\item \code{"hyphen"} (the default): preceded by a standard hypen \code{-}, e.g. \code{-1}.
+\item \code{"hyphen"} (the default): preceded by a standard hyphen \code{-}, e.g. \code{-1}.
 \item \code{"minus"}, uses a proper Unicode minus symbol. This is a typographical
 nicety that ensures \code{-} aligns with the horizontal bar of the
 the horizontal bar of \code{+}.

--- a/man/pal_dichromat.Rd
+++ b/man/pal_dichromat.Rd
@@ -21,7 +21,7 @@ if (requireNamespace("dichromat", quietly = TRUE)) {
   show_col(pal_dichromat("BluetoOrange.10")(10))
   show_col(pal_dichromat("BluetoOrange.10")(5))
 
-  # Can use with gradient_n to create a continous gradient
+  # Can use with gradient_n to create a continuous gradient
   cols <- pal_dichromat("DarkRedtoBlue.12")(12)
   show_col(pal_gradient_n(cols)(seq(0, 1, length.out = 30)))
 }


### PR DESCRIPTION
This PR fixes a handful of very minor typos that I found while reading the documentation, only one of which is associated with an issue that is linked in the commit. roxygenize was not executed because there is a GitHub action to do so upon pull requests and I have a different version of the package than the package description.

* continous to continuous
* hypen to hyphen
* adds "to" after "Use `label_number()`
* adds missing ] to [label_date()/[label_time()]
