### PR TITLE
`zero_range()` casts to numeric

### DIFF
--- a/R/bounds.R
+++ b/R/bounds.R
@@ -368,7 +368,7 @@ zero_range <- function(x, tol = 1000 * .Machine$double.eps) {
     return(TRUE)
   }
   if (length(x) != 2) cli::cli_abort("{.arg x} must be length 1 or 2")
-  if (any(is.na(x))) {
+  if (anyNA(x)) {
     return(NA)
   }
 
@@ -378,8 +378,8 @@ zero_range <- function(x, tol = 1000 * .Machine$double.eps) {
     return(TRUE)
   }
 
-  # If we reach this, then x must be (-Inf, Inf) or (Inf, -Inf)
-  if (all(is.infinite(x))) {
+  # If we reach this, then x must be (-Inf, <number>) or (<number>, Inf)
+  if (any(is.infinite(x))) {
     return(FALSE)
   }
 

--- a/R/bounds.R
+++ b/R/bounds.R
@@ -385,6 +385,7 @@ zero_range <- function(x, tol = 1000 * .Machine$double.eps) {
 
   # Take the smaller (in magnitude) value of x, and use it as the scaling
   # factor.
+  x <- as.numeric(unclass(x))
   m <- min(abs(x))
 
   # If we get here, then exactly one of the x's is 0. Return FALSE


### PR DESCRIPTION
This PR aims to fix #468 and by extension fix https://github.com/tidyverse/ggplot2/issues/6134.

Briefly, we cast input `x` to numeric before doing computations for the range.

``` r
devtools::load_all("~/packages/scales//")
#> ℹ Loading scales

range <- structure(c(1234, 7380), class = "difftime", units = "secs")

zero_range(range)
#> [1] FALSE

ggplot2::resolution(range, zero = FALSE)
#> [1] 6146
```

<sup>Created on 2024-10-11 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
