### PR TITLE
Remove unreachable branch of logic in `recycle_common()`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -73,11 +73,7 @@ recycle_common <- function(..., size = NULL, call = caller_env()) {
   n <- setdiff(n, 1L)
   ns <- length(n)
 
-  if (ns == 0) { # All have length 1
-    if (is.null(size)) {
-      return(xs)
-    }
-  } else if (ns == 1) {
+  if (ns == 1) {
     if (is.null(size)) {
       size <- n
     } else if (n != size) {


### PR DESCRIPTION
As pointed out off-github, there was a non-existing `xs` variable that was returned via `recycle_common()`.
Upon further reflection, we can never reach the state wherein that value had to be returned, so in this PR we remove it.