### PR TITLE
Leave out integration with `transform_exp()` for now

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
   ranges (#435).
 * New `label_date_short(leading)` argument to replace leading zeroes (#442)
 * `breaks_pretty()` will return the input limit when it has no range (#446)
-* `transform_exp()` now has more sensible breaks, available in `breaks_exp()` 
+* `breaks_exp()` now provides more sensible breaks for the exponential transform
   (@teunbrand, #405).
 * The scales package now keeps track of known palettes. These can be retrieved
   using `get_palette()` or registered using `set_palette()` (#396).

--- a/R/transform-numeric.R
+++ b/R/transform-numeric.R
@@ -255,8 +255,7 @@ transform_exp <- function(base = exp(1)) {
     function(x) base^x,
     function(x) log(x, base = base),
     d_transform = function(x) base^x * log(base),
-    d_inverse = function(x) 1 / x / log(base),
-    breaks = breaks_exp(),
+    d_inverse = function(x) 1 / x / log(base)
   )
 }
 


### PR DESCRIPTION
As title indicates.

For posterity, we're leaving out this change for now because it breaks one of ggplot2's tests.
We can integrate the breaks again when ggplot2 is ready.