### PR TITLE
Add check for hms installation in `transform_hms()`

### DIFF
--- a/R/transform-date.R
+++ b/R/transform-date.R
@@ -120,6 +120,7 @@ timespan_trans <- transform_timespan
 #' @rdname transform_timespan
 #' @export
 transform_hms <- function() {
+  check_installed("hms", "for the 'hms' transformation.")
   new_transform(
     "hms",
     transform = function(x) {


### PR DESCRIPTION
Apologies for the cold PR. I've now ran twice into the surprise that `transform_hms()` via `ggplot2::scale_x_time()` doesn't work because {hms} is a suggested dependency. This PR prompts users to install it.