### PR TITLE
Fix transform_time() because of lubridate incompatibility

### DIFF
--- a/R/transform-date.R
+++ b/R/transform-date.R
@@ -43,7 +43,7 @@ from_date <- function(x) {
 transform_time <- function(tz = NULL) {
   force(tz)
   to_time <- function(x) {
-    structure(x, class = c("POSIXt", "POSIXct"), tzone = tz)
+    structure(x, class = c("POSIXct", "POSIXt"), tzone = tz)
   }
 
   from_time <- function(x) {


### PR DESCRIPTION
Hi,

this change is really minor, but fixes a strange incompatibility with `lubridate`.

The bug:
```r
library(scales)
library(lubridate)

fun <- transform_time("UTC")
fun(as_datetime("2024-01-05")) + days(1)
#> Error: Incompatible classes: <POSIXt> + <Period>
```

This bug occurs in the wild, since `scales::transform_time()` is the default transformation for `ggplot2::scale_x_datetime()`.

The underlying problem is that `lubridate` only provides a method for `POSIXct` and not for `POSIXt`. And the order of the classes is therefore important.
https://github.com/tidyverse/lubridate/blob/fea9692686dcb0a968fa068d7f8dfdb41bbea581/R/ops-addition.r#L129

Also, the new order of the classes is the default order of `as.POSIXct`: 
```r
class(as.POSIXct("2024-01-05"))
#> [1] "POSIXct" "POSIXt" 
```
Fixing this problem in `scales` seemed the easiest, since the alternative would be adding a lot of new methods to `lubridate`.

I don't know if there is a reason for the inverse class order. But I hope this is an easy fix.

Greetings
Alex

